### PR TITLE
chore: bump version to 2.1.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -50,7 +50,7 @@ body:
     attributes:
       label: outlook-mcp version
       description: Run `outlook-mcp --version` or check package.json
-      placeholder: '2.0.0'
+      placeholder: '2.1.0'
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0] - 2026-02
+
+### Changed
+
+- Migrated ESLint 8 to ESLint 9 with flat config
+- Replaced gitleaks with GitHub Advanced Security secret scanning
+- Hardened security, cleaned up logging, improved CI pipeline
+
+### Added
+
+- Comprehensive test coverage across all modules (375 tests, 14 suites)
+- Codecov integration with coverage badge
+- Comprehensive Azure setup guide in documentation
+- Full documentation refresh with LBA branding and GitHub templates
+
+### Fixed
+
+- Formatted `codecov.yml` for Prettier compatibility
+- Resolved CI failures in formatting and security audit steps
+
+### Dependencies
+
+- `actions/checkout` v4 to v6
+- `actions/setup-node` v4 to v6
+- `codecov/codecov-action` v4 to v5
+- `@commitlint/cli` to v20, `supertest` to v7.2
+- `prettier` and `dotenv` bumped to latest
+
 ## [2.0.0] - 2024-12
 
 ### Added

--- a/config.js
+++ b/config.js
@@ -22,7 +22,7 @@ const homeDir =
 module.exports = {
   // Server information
   SERVER_NAME: 'outlook-assistant',
-  SERVER_VERSION: '2.0.0',
+  SERVER_VERSION: '2.1.0',
 
   // Test mode setting
   USE_TEST_MODE: process.env.USE_TEST_MODE === 'true',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@littlebearapps/outlook-mcp",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@littlebearapps/outlook-mcp",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@littlebearapps/outlook-mcp",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "MCP server for Claude to access Outlook data via Microsoft Graph API",
   "main": "index.js",
   "bin": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1618,6 +1618,11 @@
   resolved "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz"
   integrity sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==
 
+"@unrs/resolver-binding-linux-x64-musl@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz"
+  integrity sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==
+
 accepts@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz"


### PR DESCRIPTION
## Summary

- Bump version from 2.0.0 to 2.1.0 across package.json, config.js, and bug report template
- Add CHANGELOG.md entry for v2.1.0 documenting all changes since v2.0.0
- Update package-lock.json and yarn.lock for version consistency

## Changes in v2.1.0

### Changed
- Migrated ESLint 8 to ESLint 9 with flat config
- Replaced gitleaks with GitHub Advanced Security secret scanning
- Hardened security, cleaned up logging, improved CI pipeline

### Added
- Comprehensive test coverage across all modules (375 tests, 14 suites)
- Codecov integration with coverage badge
- Comprehensive Azure setup guide in documentation
- Full documentation refresh with LBA branding and GitHub templates

### Fixed
- Formatted `codecov.yml` for Prettier compatibility
- Resolved CI failures in formatting and security audit steps

### Dependencies
- `actions/checkout` v4 to v6
- `actions/setup-node` v4 to v6
- `codecov/codecov-action` v4 to v5
- `@commitlint/cli` to v20, `supertest` to v7.2
- `prettier` and `dotenv` bumped to latest

## Test plan

- [x] ESLint passes (0 errors, 0 warnings)
- [x] Prettier check passes (all files formatted)
- [x] Jest tests pass (375 tests, 14 suites)
- [x] npm audit passes (0 vulnerabilities)
- [ ] CI pipeline passes on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)