### PR TITLE
feat: v3.2.0 — fix 7 bugs, add 6 enhancements (#46-#58)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.0] - 2026-02
+
+### Fixed
+
+- **Nonexistent folder silent fallback** — `search-emails` with an invalid `folder` now throws an error instead of silently falling back to inbox (#46)
+- **`count=0` returns all emails** — `search-emails` now validates that `count` must be at least 1; uses nullish coalescing to correctly handle `count=0` (#47)
+- **read-email minimal shows "No content"** — minimal verbosity now uses a dedicated `read-minimal` field preset that includes `bodyPreview` and `toRecipients`; shows body preview instead of "No content"; only renders `**To:**` when recipients exist (#48)
+- **HTML body Content-Type shows "text"** — `send-email` HTML detection now matches `<div>`, `<p>`, `<br>`, `<table>`, `<span>`, `<a `, `<img>`, `<strong>`, `<em>`, `<b>`, `<i>` — not just `<html` (#49)
+- **Conversation export error on personal accounts** — `export` and `read-email` conversation operations now catch `ErrorInvalidUrlQueryFilter`/`InefficientFilter` errors and return a friendly message suggesting individual message IDs instead (#50)
+- **list-events times in UTC not local timezone** — calendar events now display in `Australia/Melbourne` timezone using `toLocaleString('en-AU')` with proper UTC normalisation (#51)
+- **Rule sequence shows positional index** — rule listing now displays `[sequence] Name` instead of `1. Name - Sequence: N`, correctly showing the actual Graph API sequence value (#52)
+
+### Added
+
+- **auth `about` diagnostics** — `auth` tool with `action=about` now shows tool count, scopes, module breakdown, timezone, test mode, rate limit, and recipient allowlist configuration (#53)
+- **folders `action=delete`** — delete mail folders by ID or name with protected folder guard (Inbox, Drafts, Sent, etc. cannot be deleted); tool now has `destructiveHint: true` (#54)
+- **manage-rules `action=delete`** — delete inbox rules by name or ID; tool now has `destructiveHint: true` (#55)
+- **Contact minimal verbosity** — `manage-contact` at `outputVerbosity=minimal` now shows only name and email (no phone, company, or ID), distinct from standard verbosity (#56)
+- **Settings section-specific formatting** — `mailbox-settings` with `section=workingHours`, `automaticRepliesSetting`, `language`, or `timeZone` now returns formatted output instead of raw JSON (#57)
+- **Auto-reply message warning** — enabling auto-replies without providing messages now warns if no message is configured, or notes when a previously configured message will be reused (#58)
+
+### Changed
+
+- `folders` tool annotations updated to `destructiveHint: true` (now includes delete action)
+- `manage-rules` tool annotations updated to `destructiveHint: true` (now includes delete action)
+- Security audit: updated `hono` and `@hono/node-server` transitive dependencies to fix 2 high-severity vulnerabilities
+
 ## [3.1.0] - 2026-03
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md - outlook-mcp
 
-MCP server for Microsoft Outlook via Graph API. 20 consolidated tools across 9 modules (reduced from 55 for token efficiency).
+MCP server for Microsoft Outlook via Graph API (v3.2.0). 20 consolidated tools across 9 modules.
 
 ## Commands
 
@@ -153,10 +153,20 @@ Mock data defined in `utils/mock-data.js`.
 | list/create-rule, edit-rule-sequence | `manage-rules` | `action` param |
 | about, authenticate, check-auth-status | `auth` | `action` param |
 
+## Promotion & Directory Listings
+
+The project has been submitted to major MCP directories (2026-03-05). Tracker with PR/issue links, manual submission drafts, and Reddit post drafts:
+
+→ `docs/promotion/directory-submissions.md`
+
+**Submitted (automated):** punkpeye, appcypher, TensorBlock, YuzeHao2023 awesome-mcp-servers (PRs); Cline MCP Marketplace, mcp.so (issues)
+**Manual required:** PulseMCP, Smithery.ai, Glama.ai (web forms — drafts in tracker)
+
 ## See Also
 
 - `README.md` - Full documentation, Azure setup, tool reference
 - `docs/quickrefs/tools-reference.md` - Tools quick reference
+- `docs/promotion/directory-submissions.md` - Directory submission tracker
 - `.env.example` - Environment template
 
 # currentDate

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 
 <p align="center">
-  <strong>Let Claude read, search, send, and manage your Outlook email, calendar, and contacts — all from the conversation.</strong>
+  <strong>Let your AI assistant read, search, send, and manage your Outlook email, calendar, and contacts — all from the conversation.</strong>
 </p>
 
 <p align="center">
@@ -14,7 +14,7 @@
   <a href="https://nodejs.org"><img src="https://img.shields.io/badge/node-%3E%3D18.0.0-brightgreen" alt="Node.js" /></a>
 </p>
 
-Outlook MCP connects Claude and other AI assistants to your Microsoft Outlook account through the [Model Context Protocol](https://modelcontextprotocol.io/). Ask Claude to search your inbox, send emails, schedule meetings, manage contacts, and configure mailbox settings — without leaving the conversation.
+Outlook MCP connects AI assistants to your Microsoft Outlook account through the [Model Context Protocol](https://modelcontextprotocol.io/). Ask your AI assistant to search your inbox, send emails, schedule meetings, manage contacts, and configure mailbox settings — without leaving the conversation. Works with Claude, Cursor, Windsurf, and any MCP-compatible client.
 
 **Works with personal Outlook.com and work/school Microsoft 365 accounts.**
 
@@ -35,10 +35,10 @@ Outlook MCP connects Claude and other AI assistants to your Microsoft Outlook ac
 
 | Without Outlook MCP | With Outlook MCP |
 |---------------------|------------------|
-| Switch between Claude and Outlook to manage email | Read, search, send, and export emails directly from Claude |
+| Switch between your AI tool and Outlook to manage email | Read, search, send, and export emails directly from your AI assistant |
 | Manually search and export email threads | Full email tools including search, threading, and bulk export |
 | Context-switch for calendar and contacts | Manage calendar events, contacts, and settings in one place |
-| Copy-paste email content into conversations | Claude reads your emails natively with full context |
+| Copy-paste email content into conversations | Your AI assistant reads your emails natively with full context |
 | No programmatic access to mailbox rules or categories | Create inbox rules, manage categories, configure auto-replies |
 
 ## Features
@@ -50,8 +50,8 @@ Outlook MCP connects Claude and other AI assistants to your Microsoft Outlook ac
 | **Contacts** | 2 | `manage-contact` (list/search/get/create/update/delete), `search-people` |
 | **Categories** | 3 | `manage-category` (CRUD), `apply-category`, `manage-focused-inbox` |
 | **Settings** | 1 | `mailbox-settings` (get/set auto-replies/set working hours) |
-| **Folder** | 1 | `folders` (list/create/move/stats) |
-| **Rules** | 1 | `manage-rules` (list/create/reorder) |
+| **Folder** | 1 | `folders` (list/create/move/stats/delete) |
+| **Rules** | 1 | `manage-rules` (list/create/reorder/delete) |
 | **Advanced** | 2 | `access-shared-mailbox`, `find-meeting-rooms` |
 | **Auth** | 1 | `auth` (status/authenticate/about) |
 
@@ -125,9 +125,9 @@ You need a Microsoft Azure app registration to authenticate. See the **[Azure Se
 3. Add Microsoft Graph delegated permissions (Mail, Calendar, Contacts)
 4. Create a client secret and copy the **Value** (not the Secret ID)
 
-### 3. Configure Claude Desktop
+### 3. Configure Your MCP Client
 
-Add to your Claude Desktop config (`claude_desktop_config.json`):
+Add to your MCP client config. For Claude Desktop (`claude_desktop_config.json`):
 
 ```json
 {
@@ -147,11 +147,11 @@ Add to your Claude Desktop config (`claude_desktop_config.json`):
 ### 4. Authenticate
 
 1. Start the auth server: `outlook-mcp-auth` (or `npx @littlebearapps/outlook-mcp-auth`)
-2. In Claude, use the `auth` tool with `action=authenticate` to get an OAuth URL
+2. In your AI assistant, use the `auth` tool with `action=authenticate` to get an OAuth URL
 3. Open the URL, sign in with your Microsoft account, and grant permissions
 4. Tokens are saved locally and refresh automatically
 
-> **Note**: The auth server needs `OUTLOOK_CLIENT_ID` and `OUTLOOK_CLIENT_SECRET` environment variables. The Claude Desktop/Code `"env"` config only applies to the MCP server process — when running the auth server separately, ensure these are set in a `.env` file or exported in your shell.
+> **Note**: The auth server needs `OUTLOOK_CLIENT_ID` and `OUTLOOK_CLIENT_SECRET` environment variables. Your MCP client's `"env"` config only applies to the MCP server process — when running the auth server separately, ensure these are set in a `.env` file or exported in your shell.
 
 ## Installation
 
@@ -233,9 +233,9 @@ USE_TEST_MODE=false
 
 > **Note:** The server also accepts `MS_CLIENT_ID` and `MS_CLIENT_SECRET` for backwards compatibility.
 
-### Claude Desktop Configuration
+### MCP Client Configuration
 
-Add to your Claude Desktop config:
+Add to your MCP client config (example for Claude Desktop):
 
 ```json
 {
@@ -279,11 +279,11 @@ npm run auth-server
 
 This starts a local server on port 3333 to handle the OAuth callback.
 
-> **Note**: The auth server reads `OUTLOOK_CLIENT_ID` and `OUTLOOK_CLIENT_SECRET` from environment variables (or `MS_CLIENT_ID`/`MS_CLIENT_SECRET`). When running the auth server separately, ensure your `.env` file is in the project root or export the variables in your shell. The Claude Desktop/Code `"env"` config only applies to the MCP server process, not a separately-started auth server.
+> **Note**: The auth server reads `OUTLOOK_CLIENT_ID` and `OUTLOOK_CLIENT_SECRET` from environment variables (or `MS_CLIENT_ID`/`MS_CLIENT_SECRET`). When running the auth server separately, ensure your `.env` file is in the project root or export the variables in your shell. Your MCP client's `"env"` config only applies to the MCP server process, not a separately-started auth server.
 
 ### Step 2: Authenticate
 
-1. In Claude, use the `auth` tool with `action=authenticate`
+1. In your AI assistant, use the `auth` tool with `action=authenticate`
 2. Open the provided URL in your browser
 3. Sign in with your Microsoft account and grant permissions
 4. Tokens are saved to `~/.outlook-mcp-tokens.json` and refresh automatically

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -67,8 +67,8 @@ Every tool carries [MCP annotations](https://modelcontextprotocol.io/docs/concep
 
 | Annotation | Meaning | Effect |
 |------------|---------|--------|
-| `readOnlyHint: true` | Tool only reads data | Claude Code auto-approves (no prompt) |
-| `destructiveHint: true` | Tool can cause irreversible changes | Claude prompts for explicit confirmation |
+| `readOnlyHint: true` | Tool only reads data | MCP clients auto-approve (no prompt) |
+| `destructiveHint: true` | Tool can cause irreversible changes | Client prompts for explicit confirmation |
 | `idempotentHint: true` | Safe to retry without side effects | Client may auto-retry on failure |
 
 - **6 read-only tools** are auto-approved (search, read, list operations)

--- a/auth/oauth-server.js
+++ b/auth/oauth-server.js
@@ -28,9 +28,9 @@ const templates = {
   authSuccess: `
     <html>
       <body style="font-family: Arial, sans-serif; text-align: center; margin-top: 50px;">
-        <h1 style="color: #2ecc71;">✅ Authentication Successful</h1>
+        <h1 style="color: #2ecc71;">&#10003; Authentication Successful</h1>
         <p>You have successfully authenticated with Microsoft Graph API.</p>
-        <p>You can close this window.</p>
+        <p>You can close this window and return to your AI assistant.</p>
       </body>
     </html>`,
   tokenExchangeError: (error) => `
@@ -51,10 +51,14 @@ const templates = {
     </html>`,
 };
 
-function createAuthConfig(envPrefix = 'MS_') {
+function createAuthConfig(envPrefix = 'OUTLOOK_') {
   return {
-    clientId: process.env[`${envPrefix}CLIENT_ID`] || '',
-    clientSecret: process.env[`${envPrefix}CLIENT_SECRET`] || '',
+    clientId:
+      process.env[`${envPrefix}CLIENT_ID`] || process.env.MS_CLIENT_ID || '',
+    clientSecret:
+      process.env[`${envPrefix}CLIENT_SECRET`] ||
+      process.env.MS_CLIENT_SECRET ||
+      '',
     redirectUri:
       process.env[`${envPrefix}REDIRECT_URI`] ||
       'http://localhost:3333/auth/callback',
@@ -70,7 +74,12 @@ function createAuthConfig(envPrefix = 'MS_') {
   };
 }
 
-function setupOAuthRoutes(app, tokenStorage, authConfig, envPrefix = 'MS_') {
+function setupOAuthRoutes(
+  app,
+  tokenStorage,
+  authConfig,
+  envPrefix = 'OUTLOOK_'
+) {
   if (!authConfig) {
     authConfig = createAuthConfig(envPrefix);
   }

--- a/auth/token-storage.js
+++ b/auth/token-storage.js
@@ -10,8 +10,9 @@ class TokenStorage {
         process.env.HOME || process.env.USERPROFILE,
         '.outlook-mcp-tokens.json'
       ),
-      clientId: process.env.MS_CLIENT_ID,
-      clientSecret: process.env.MS_CLIENT_SECRET,
+      clientId: process.env.OUTLOOK_CLIENT_ID || process.env.MS_CLIENT_ID,
+      clientSecret:
+        process.env.OUTLOOK_CLIENT_SECRET || process.env.MS_CLIENT_SECRET,
       redirectUri:
         process.env.MS_REDIRECT_URI || 'http://localhost:3333/auth/callback',
       scopes: (
@@ -29,7 +30,7 @@ class TokenStorage {
 
     if (!this.config.clientId || !this.config.clientSecret) {
       console.warn(
-        'TokenStorage: MS_CLIENT_ID or MS_CLIENT_SECRET is not configured. Token operations might fail.'
+        'TokenStorage: OUTLOOK_CLIENT_ID or OUTLOOK_CLIENT_SECRET is not configured. Token operations might fail.'
       );
     }
   }

--- a/auth/tools.js
+++ b/auth/tools.js
@@ -9,11 +9,37 @@ const tokenManager = require('./token-manager');
  * @returns {object} - MCP response
  */
 async function handleAbout() {
+  const scopes = config.AUTH_CONFIG.scopes.filter(
+    (s) => s !== 'offline_access'
+  );
+  const testMode = config.USE_TEST_MODE ? 'Enabled' : 'Disabled';
+  const rateLimit =
+    process.env.OUTLOOK_MAX_EMAILS_PER_SESSION || 'Unlimited (no limit set)';
+  const allowlist =
+    process.env.OUTLOOK_ALLOWED_RECIPIENTS || 'None (all recipients allowed)';
+
+  const lines = [
+    `# Outlook MCP Server v${config.SERVER_VERSION}\n`,
+    `Provides access to Microsoft Outlook email, calendar, and contacts through Microsoft Graph API.\n`,
+    `## Diagnostics\n`,
+    `| Setting | Value |`,
+    `|---------|-------|`,
+    `| Tools | 20 across 9 modules |`,
+    `| Modules | auth, email, calendar, folder, rules, contacts, categories, settings, advanced |`,
+    `| Timezone | ${config.DEFAULT_TIMEZONE} |`,
+    `| Test Mode | ${testMode} |`,
+    `| Rate Limit | ${rateLimit} |`,
+    `| Recipient Allowlist | ${allowlist} |`,
+    `| Scopes | ${scopes.length} configured |`,
+    ``,
+    `**Scopes**: ${scopes.join(', ')}`,
+  ];
+
   return {
     content: [
       {
         type: 'text',
-        text: `📧 MODULAR Outlook Assistant MCP Server v${config.SERVER_VERSION} 📧\n\nProvides access to Microsoft Outlook email, calendar, and contacts through Microsoft Graph API.\nImplemented with a modular architecture for improved maintainability.`,
+        text: lines.join('\n'),
       },
     ],
   };

--- a/calendar/list.js
+++ b/calendar/list.js
@@ -49,17 +49,28 @@ async function handleListEvents(args) {
     }
 
     // Format results
+    const tz = config.DEFAULT_TIMEZONE;
     const eventList = response.value
       .map((event, index) => {
-        const startDate = new Date(event.start.dateTime).toLocaleString(
-          event.start.timeZone
-        );
-        const endDate = new Date(event.end.dateTime).toLocaleString(
-          event.end.timeZone
-        );
+        const startDt = event.start.dateTime.endsWith('Z')
+          ? event.start.dateTime
+          : event.start.dateTime + 'Z';
+        const endDt = event.end.dateTime.endsWith('Z')
+          ? event.end.dateTime
+          : event.end.dateTime + 'Z';
+        const startDate = new Date(startDt).toLocaleString('en-AU', {
+          timeZone: tz,
+          dateStyle: 'medium',
+          timeStyle: 'short',
+        });
+        const endDate = new Date(endDt).toLocaleString('en-AU', {
+          timeZone: tz,
+          dateStyle: 'medium',
+          timeStyle: 'short',
+        });
         const location = event.location.displayName || 'No location';
 
-        return `${index + 1}. ${event.subject} - Location: ${location}\nStart: ${startDate}\nEnd: ${endDate}\nSubject: ${event.subject}\nSummary: ${event.bodyPreview}\nID: ${event.id}\n`;
+        return `${index + 1}. ${event.subject} - Location: ${location}\nStart: ${startDate}\nEnd: ${endDate}\nSummary: ${event.bodyPreview}\nID: ${event.id}\n`;
       })
       .join('\n');
 

--- a/config.js
+++ b/config.js
@@ -22,7 +22,7 @@ const homeDir =
 module.exports = {
   // Server information
   SERVER_NAME: 'outlook-assistant',
-  SERVER_VERSION: '3.1.0',
+  SERVER_VERSION: '3.2.0',
 
   // Test mode setting
   USE_TEST_MODE: process.env.USE_TEST_MODE === 'true',

--- a/contacts/index.js
+++ b/contacts/index.js
@@ -13,6 +13,7 @@ const { ensureAuthenticated } = require('../auth');
  * Contact field presets for different use cases
  */
 const CONTACT_FIELDS = {
+  minimal: ['id', 'displayName', 'emailAddresses'],
   list: [
     'id',
     'displayName',
@@ -60,23 +61,26 @@ function formatContact(contact, verbosity = 'standard') {
     lines.push(`**Email**: ${emails}`);
   }
 
-  // Phone numbers
-  const phones = [];
-  if (contact.mobilePhone) phones.push(`Mobile: ${contact.mobilePhone}`);
-  if (contact.businessPhones?.length > 0)
-    phones.push(`Work: ${contact.businessPhones[0]}`);
-  if (contact.homePhones?.length > 0)
-    phones.push(`Home: ${contact.homePhones[0]}`);
-  if (phones.length > 0) {
-    lines.push(`**Phone**: ${phones.join(' | ')}`);
-  }
+  // Skip phone/company/ID at minimal verbosity
+  if (verbosity !== 'minimal') {
+    // Phone numbers
+    const phones = [];
+    if (contact.mobilePhone) phones.push(`Mobile: ${contact.mobilePhone}`);
+    if (contact.businessPhones?.length > 0)
+      phones.push(`Work: ${contact.businessPhones[0]}`);
+    if (contact.homePhones?.length > 0)
+      phones.push(`Home: ${contact.homePhones[0]}`);
+    if (phones.length > 0) {
+      lines.push(`**Phone**: ${phones.join(' | ')}`);
+    }
 
-  // Company info
-  if (contact.companyName || contact.jobTitle) {
-    const company = [contact.jobTitle, contact.companyName]
-      .filter(Boolean)
-      .join(' at ');
-    lines.push(`**Company**: ${company}`);
+    // Company info
+    if (contact.companyName || contact.jobTitle) {
+      const company = [contact.jobTitle, contact.companyName]
+        .filter(Boolean)
+        .join(' at ');
+      lines.push(`**Company**: ${company}`);
+    }
   }
 
   // Full verbosity extras
@@ -107,7 +111,9 @@ function formatContact(contact, verbosity = 'standard') {
     }
   }
 
-  lines.push(`*ID: \`${contact.id}\`*`);
+  if (verbosity !== 'minimal') {
+    lines.push(`*ID: \`${contact.id}\`*`);
+  }
   lines.push('');
 
   return lines.join('\n');
@@ -125,7 +131,11 @@ async function handleListContacts(args) {
     const accessToken = await ensureAuthenticated();
 
     const fields =
-      verbosity === 'full' ? CONTACT_FIELDS.full : CONTACT_FIELDS.list;
+      verbosity === 'full'
+        ? CONTACT_FIELDS.full
+        : verbosity === 'minimal'
+          ? CONTACT_FIELDS.minimal
+          : CONTACT_FIELDS.list;
     const endpoint = folder
       ? `me/contactFolders/${folder}/contacts`
       : 'me/contacts';
@@ -193,7 +203,11 @@ async function handleSearchContacts(args) {
     const accessToken = await ensureAuthenticated();
 
     const fields =
-      verbosity === 'full' ? CONTACT_FIELDS.full : CONTACT_FIELDS.list;
+      verbosity === 'full'
+        ? CONTACT_FIELDS.full
+        : verbosity === 'minimal'
+          ? CONTACT_FIELDS.minimal
+          : CONTACT_FIELDS.list;
     const endpoint = 'me/contacts';
 
     // Build filter for name — emailAddresses/any() lambda is unreliable on personal accounts

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@
 
 New to Outlook MCP? Start here:
 
-- [Connect Outlook to Claude](how-to/getting-started/connect-outlook-to-claude.md) — Install, configure, and authenticate
+- [Connect Outlook to Your AI Assistant](how-to/getting-started/connect-outlook-to-claude.md) — Install, configure, and authenticate
 - [Azure Setup Guide](guides/azure-setup.md) — Create an Azure app registration and connect your Microsoft account
 - [README](../README.md) — Full feature overview, quick start, and configuration
 

--- a/docs/guides/azure-setup.md
+++ b/docs/guides/azure-setup.md
@@ -176,9 +176,9 @@ You now have two values:
 - **Application (client) ID** → `OUTLOOK_CLIENT_ID`
 - **Client secret Value** → `OUTLOOK_CLIENT_SECRET`
 
-### Option A: Claude Desktop Config (Recommended)
+### Option A: MCP Client Config (Recommended)
 
-Add to your Claude Desktop `claude_desktop_config.json`:
+Add to your MCP client config (example for Claude Desktop `claude_desktop_config.json`):
 
 ```json
 {
@@ -215,7 +215,7 @@ USE_TEST_MODE=false
 npm run auth-server
 ```
 
-> **Note**: The auth server reads `OUTLOOK_CLIENT_ID` and `OUTLOOK_CLIENT_SECRET` from environment variables (or the legacy `MS_CLIENT_ID`/`MS_CLIENT_SECRET` aliases). When running from source, ensure your `.env` file is in the project root. When using Claude Desktop/Code, the env vars from your MCP config are passed automatically to the server process.
+> **Note**: The auth server reads `OUTLOOK_CLIENT_ID` and `OUTLOOK_CLIENT_SECRET` from environment variables (or the legacy `MS_CLIENT_ID`/`MS_CLIENT_SECRET` aliases). When running from source, ensure your `.env` file is in the project root. When using an MCP client, the env vars from your MCP config are passed automatically to the server process.
 
 You should see:
 
@@ -225,7 +225,7 @@ Auth server listening on http://localhost:3333
 
 ### 2. Authenticate
 
-In Claude, use the `auth` tool with `action=authenticate`. It returns a Microsoft login URL.
+In your AI assistant, use the `auth` tool with `action=authenticate`. It returns a Microsoft login URL.
 
 1. Open the URL in your browser
 2. Sign in with your Microsoft account
@@ -236,7 +236,7 @@ Tokens are saved to `~/.outlook-mcp-tokens.json` and refresh automatically.
 
 ### 3. Verify Access
 
-In Claude, use the `auth` tool with `action=status`. You should see:
+In your AI assistant, use the `auth` tool with `action=status`. You should see:
 
 ```
 Authenticated as: your.email@outlook.com
@@ -291,7 +291,7 @@ Then try `search-emails` to confirm email access is working.
 ```bash
 rm ~/.outlook-mcp-tokens.json
 npm run auth-server
-# Then use the auth tool with action=authenticate in Claude
+# Then use the auth tool with action=authenticate in your AI assistant
 ```
 
 ---
@@ -318,14 +318,14 @@ npm run auth-server
 ```bash
 rm ~/.outlook-mcp-tokens.json
 npm run auth-server
-# Then use the auth tool with action=authenticate in Claude
+# Then use the auth tool with action=authenticate in your AI assistant
 ```
 
 After re-authenticating, use the `auth` tool with `action=status` to verify the new scopes appear in the token.
 
 ## What's Next?
 
-- [Connect Outlook to Claude](../how-to/getting-started/connect-outlook-to-claude.md) — Install, configure your MCP client, and authenticate
+- [Connect Outlook to Your AI Assistant](../how-to/getting-started/connect-outlook-to-claude.md) — Install, configure your MCP client, and authenticate
 - [README](../../README.md) — Full feature overview and configuration
 - [Tools Reference](../quickrefs/tools-reference.md) — All 20 tools with parameters
 - [Back to Docs](../README.md)

--- a/docs/how-to/advanced/access-shared-mailboxes.md
+++ b/docs/how-to/advanced/access-shared-mailboxes.md
@@ -72,7 +72,7 @@ Your Microsoft account must also have been granted access to the shared mailbox 
 
 - This tool is read-only — you can't send from a shared mailbox through Outlook MCP
 - Use `outputVerbosity: "minimal"` for quick checks on high-volume shared inboxes
-- Auto-approved by Claude Code (read-only tool)
+- Auto-approved by MCP clients that support annotations (read-only tool)
 
 ## Related
 

--- a/docs/how-to/ai-agents/using-outlook-mcp-in-agents.md
+++ b/docs/how-to/ai-agents/using-outlook-mcp-in-agents.md
@@ -37,9 +37,9 @@ This guide helps AI agents and their developers make effective use of Outlook MC
 
 Every tool includes MCP annotations that indicate its safety profile:
 
-| Annotation | Meaning | Effect in Claude |
-|------------|---------|-----------------|
-| `readOnlyHint: true` | No side effects | Auto-approved |
+| Annotation | Meaning | Effect in MCP clients |
+|------------|---------|----------------------|
+| `readOnlyHint: true` | No side effects | Auto-approved (in clients that support it) |
 | `destructiveHint: true` | Can cause irreversible changes | Requires user confirmation |
 | `idempotentHint: true` | Safe to retry | No special handling |
 | `openWorldHint: true` | Communicates externally | Requires user confirmation |

--- a/docs/how-to/calendar/create-calendar-events.md
+++ b/docs/how-to/calendar/create-calendar-events.md
@@ -1,12 +1,12 @@
 ---
 title: "How to Create Calendar Events"
-description: "Schedule meetings and events from Claude, including adding attendees and event descriptions."
+description: "Schedule meetings and events through your AI assistant, including adding attendees and event descriptions."
 tags: [outlook-mcp, calendar, how-to]
 ---
 
 # How to Create Calendar Events
 
-Schedule meetings, appointments, and events directly from Claude with attendees, descriptions, and locations.
+Schedule meetings, appointments, and events directly from your AI assistant with attendees, descriptions, and locations.
 
 ## Create a Simple Event
 
@@ -73,7 +73,7 @@ Times are interpreted using the server's configured timezone (default: `Australi
 
 ## Tips
 
-- Use plain language with Claude — it will convert your request into the right parameters and times
+- Use plain language — your AI assistant will convert your request into the right parameters and times
 - The body field supports plain text — add agendas, links, or preparation notes
 - Check your calendar first with `list-events` to avoid double-booking
 - Omit the `Z` suffix on times unless you specifically mean UTC

--- a/docs/how-to/calendar/manage-event-responses.md
+++ b/docs/how-to/calendar/manage-event-responses.md
@@ -65,7 +65,7 @@ Delete removes the event from your calendar without notifying anyone. Use this f
 | `eventId` | The event ID (from `list-events`) | Yes |
 | `comment` | Message sent with decline/cancel | No |
 
-> **Note**: This tool is marked as destructive. Claude will ask for your confirmation before declining, cancelling, or deleting any event.
+> **Note**: This tool is marked as destructive. Your AI assistant will ask for your confirmation before declining, cancelling, or deleting any event.
 
 ## Tips
 

--- a/docs/how-to/calendar/view-upcoming-events.md
+++ b/docs/how-to/calendar/view-upcoming-events.md
@@ -1,12 +1,12 @@
 ---
 title: "How to View Upcoming Calendar Events"
-description: "List your scheduled events so Claude can help with scheduling, reminders, and meeting preparation."
+description: "List your scheduled events so your AI assistant can help with scheduling, reminders, and meeting preparation."
 tags: [outlook-mcp, calendar, how-to]
 ---
 
 # How to View Upcoming Calendar Events
 
-Check what's coming up on your calendar so Claude can help with scheduling, preparation, or summarising your day.
+Check what's coming up on your calendar so your AI assistant can help with scheduling, preparation, or summarising your day.
 
 ## List Your Next Events
 
@@ -47,7 +47,7 @@ Each event shows:
 
 - `list-events` is read-only and auto-approved — no confirmation needed
 - Events are sorted chronologically (soonest first)
-- Ask Claude to summarise your day: "What meetings do I have today?"
+- Ask your AI assistant to summarise your day: "What meetings do I have today?"
 - Combine with email search: "Find any emails from people I'm meeting today"
 
 ## Related

--- a/docs/how-to/email/find-emails.md
+++ b/docs/how-to/email/find-emails.md
@@ -10,7 +10,7 @@ Search and filter your emails to find exactly what you need. With no search term
 
 ## List Recent Emails
 
-Ask Claude to show your latest emails:
+Ask your AI assistant to show your latest emails:
 
 > "Show me my recent emails"
 
@@ -152,7 +152,7 @@ params:
 | List (no query) | 25 | 50 |
 | Search | 10 | 50 |
 
-![Claude returning search results with email list](../../assets/screenshots/find-emails-01.png)
+![Search results with email list](../../assets/screenshots/find-emails-01.png)
 
 ## Parameter Reference
 

--- a/docs/how-to/email/send-email-safely.md
+++ b/docs/how-to/email/send-email-safely.md
@@ -1,12 +1,12 @@
 ---
 title: "How to Send Email Safely"
-description: "Compose and send emails from Claude with dry-run preview, and understand the safety controls that prevent accidental sends."
+description: "Compose and send emails with dry-run preview, and understand the safety controls that prevent accidental sends."
 tags: [outlook-mcp, email, how-to]
 ---
 
 # How to Send Email Safely
 
-Compose and send emails through Claude with built-in safety controls: dry-run preview, rate limiting, and an optional recipient allowlist.
+Compose and send emails through your AI assistant with built-in safety controls: dry-run preview, rate limiting, and an optional recipient allowlist.
 
 ## Preview Before Sending (Dry Run)
 
@@ -23,9 +23,9 @@ params:
   dryRun: true
 ```
 
-The dry run shows exactly what will be sent — recipients, subject, body — without actually sending. Review it, then ask Claude to send.
+The dry run shows exactly what will be sent — recipients, subject, body — without actually sending. Review it, then ask your AI assistant to send.
 
-![Claude showing dry-run preview with send confirmation](../../assets/screenshots/send-email-safely-01.png)
+![Dry-run preview with send confirmation](../../assets/screenshots/send-email-safely-01.png)
 
 ## Send an Email
 
@@ -39,7 +39,7 @@ params:
   body: "Hi Sarah,\n\nJust confirming our meeting tomorrow at 10am.\n\nCheers"
 ```
 
-Because `send-email` is marked as destructive, Claude will always ask for your confirmation before sending — even without dry run.
+Because `send-email` is marked as destructive, your AI assistant will always ask for your confirmation before sending — even without dry run.
 
 ## Send to Multiple Recipients
 
@@ -77,7 +77,7 @@ Options: `normal` (default), `high`, `low`.
 
 ### Confirmation Prompt
 
-Every send triggers a confirmation prompt in Claude. You must explicitly approve before the email leaves your outbox. This is enforced by the MCP `destructiveHint` annotation — it cannot be bypassed.
+Every send triggers a confirmation prompt in your AI assistant. You must explicitly approve before the email leaves your outbox. This is enforced by the MCP `destructiveHint` annotation — it cannot be bypassed.
 
 ### Rate Limiting
 
@@ -91,13 +91,13 @@ Add this to your MCP server environment variables. Once the limit is reached, fu
 
 ### Recipient Allowlist
 
-Restrict who Claude can send to:
+Restrict who your AI assistant can send to:
 
 ```
 OUTLOOK_ALLOWED_RECIPIENTS=company.com,partner.org
 ```
 
-With this set, Claude can only send to addresses ending in `@company.com` or `@partner.org`. Sends to any other domain are blocked.
+With this set, emails can only be sent to addresses ending in `@company.com` or `@partner.org`. Sends to any other domain are blocked.
 
 ![Safety configuration with allowed recipients and rate limiting](../../assets/screenshots/send-email-safely-02.png)
 

--- a/docs/how-to/email/work-with-attachments.md
+++ b/docs/how-to/email/work-with-attachments.md
@@ -50,11 +50,11 @@ The file is saved with its original filename to the specified directory.
 
 ## Download All Attachments
 
-List the attachments first, then download each one. Ask Claude:
+List the attachments first, then download each one:
 
 > "Download all attachments from that email to /tmp/attachments/"
 
-Claude will list the attachments, then download each one sequentially.
+The attachments will be listed, then downloaded sequentially.
 
 ## Parameter Reference
 

--- a/docs/how-to/getting-started/connect-outlook-to-claude.md
+++ b/docs/how-to/getting-started/connect-outlook-to-claude.md
@@ -1,12 +1,12 @@
 ---
-title: "How to Connect Outlook to Claude"
-description: "Set up Outlook MCP so Claude can read and manage your email, calendar, and contacts."
+title: "How to Connect Outlook to Your AI Assistant"
+description: "Set up Outlook MCP so your AI assistant can read and manage your email, calendar, and contacts."
 tags: [outlook-mcp, getting-started, how-to]
 ---
 
-# How to Connect Outlook to Claude
+# How to Connect Outlook to Your AI Assistant
 
-Connect your Microsoft 365 or Outlook.com account so Claude can search emails, manage your calendar, and work with contacts on your behalf.
+Connect your Microsoft 365 or Outlook.com account so your AI assistant can search emails, manage your calendar, and work with contacts on your behalf.
 
 ## Install Outlook MCP
 
@@ -101,11 +101,11 @@ Outlook MCP has two separate processes that serve different purposes:
 
 | Process | Purpose | When to run | How it runs |
 |---------|---------|-------------|-------------|
-| **MCP server** (`index.js`) | Handles all 20 Outlook tools — searching emails, reading calendar, etc. | Always (runs automatically) | Claude Desktop/Code starts it from your MCP config |
+| **MCP server** (`index.js`) | Handles all 20 Outlook tools — searching emails, reading calendar, etc. | Always (runs automatically) | Your MCP client starts it from your MCP config |
 | **Auth server** (`outlook-auth-server.js`) | Handles OAuth login — the one-time browser authentication flow | Only during initial setup or re-authentication | You start it manually with `npx @littlebearapps/outlook-mcp auth-server` |
 
 **Key points:**
-- The **MCP server** is what Claude talks to. It starts automatically when Claude Desktop or Claude Code launches.
+- The **MCP server** is what your AI assistant talks to. It starts automatically when your MCP client launches.
 - The **auth server** is a temporary helper that runs on port 3333 to receive the OAuth callback from Microsoft. You only need it when authenticating or re-authenticating.
 - After authentication succeeds, you can stop the auth server. The MCP server handles token refresh on its own.
 - Both processes need `OUTLOOK_CLIENT_ID` and `OUTLOOK_CLIENT_SECRET`. The MCP config `"env"` block provides these to the MCP server automatically. For the auth server, you need to either set them as shell environment variables or have a `.env` file in the project root.
@@ -118,15 +118,15 @@ Outlook MCP has two separate processes that serve different purposes:
 npx @littlebearapps/outlook-mcp auth-server
 ```
 
-> **Important**: The auth server needs `OUTLOOK_CLIENT_ID` and `OUTLOOK_CLIENT_SECRET` environment variables. These are **not** automatically inherited from your Claude Desktop/Code MCP config — that config only applies to the MCP server process. Either:
+> **Important**: The auth server needs `OUTLOOK_CLIENT_ID` and `OUTLOOK_CLIENT_SECRET` environment variables. These are **not** automatically inherited from your MCP client's config — that config only applies to the MCP server process. Either:
 > - Create a `.env` file in the project root (copy from `.env.example`), or
 > - Export the variables in your shell before running the command
 
-2. Ask Claude to authenticate:
+2. Ask your AI assistant to authenticate:
 
 > "Connect to my Outlook account"
 
-Claude will call the `auth` tool with `action: authenticate` and return a URL.
+Your AI assistant will call the `auth` tool with `action: authenticate` and return a URL.
 
 3. Open the URL in your browser, sign in with your Microsoft account, and grant permissions.
 
@@ -136,13 +136,13 @@ Claude will call the `auth` tool with `action: authenticate` and return a URL.
 
 ## Verify It's Working
 
-Ask Claude:
+Ask your AI assistant:
 
 > "Check my Outlook connection status"
 
-Claude calls the `auth` tool with `action: status`. You should see your email address and token expiry time.
+The `auth` tool is called with `action: status`. You should see your email address and token expiry time.
 
-![Claude showing auth tool success message](../../assets/screenshots/connect-outlook-to-claude-03.png)
+![Auth tool success message showing authenticated status](../../assets/screenshots/connect-outlook-to-claude-03.png)
 
 Then try a simple read:
 

--- a/docs/how-to/getting-started/verify-your-connection.md
+++ b/docs/how-to/getting-started/verify-your-connection.md
@@ -10,11 +10,11 @@ Check whether Outlook MCP is authenticated, see which account is connected, and 
 
 ## Check Authentication Status
 
-Ask Claude:
+Ask your AI assistant:
 
 > "Check my Outlook auth status"
 
-Claude calls the `auth` tool:
+The `auth` tool is called:
 
 ```
 tool: auth
@@ -43,7 +43,7 @@ Tokens expire periodically (typically after 1 hour, with automatic refresh). If 
 npx @littlebearapps/outlook-mcp auth-server
 ```
 
-2. Ask Claude:
+2. Ask your AI assistant:
 
 > "Re-authenticate my Outlook account"
 
@@ -119,6 +119,6 @@ See [When Your Secret Expires](../../guides/azure-setup.md#when-your-secret-expi
 
 ## Related
 
-- [Connect Outlook to Claude](connect-outlook-to-claude.md) — initial setup walkthrough
+- [Connect Outlook to Your AI Assistant](connect-outlook-to-claude.md) — initial setup walkthrough
 - [Azure Setup Guide](../../guides/azure-setup.md) — app registration and permissions
 - [Tools Reference — auth](../../quickrefs/tools-reference.md#auth-1-tool) — full parameter reference

--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -1,18 +1,18 @@
 ---
 title: "Outlook MCP How-To Guides"
-description: "Practical guides for managing Outlook email, calendar, contacts, and settings through Claude and other AI tools."
+description: "Practical guides for managing Outlook email, calendar, contacts, and settings through AI assistants."
 tags: [outlook-mcp, how-to, index]
 ---
 
 # Outlook MCP How-To Guides
 
-Practical guides for managing your Microsoft 365 email, calendar, contacts, and settings through Claude and other MCP-compatible AI tools.
+Practical guides for managing your Microsoft 365 email, calendar, contacts, and settings through MCP-compatible AI assistants.
 
 ## Getting Started
 
 | Guide | What it covers |
 |-------|---------------|
-| [Connect Outlook to Claude](getting-started/connect-outlook-to-claude.md) | Install, Azure app setup, Claude Desktop/Code config, first authentication |
+| [Connect Outlook to Your AI Assistant](getting-started/connect-outlook-to-claude.md) | Install, Azure app setup, MCP client config, first authentication |
 | [Verify Your Connection](getting-started/verify-your-connection.md) | Check auth status, re-authenticate, troubleshoot connection issues, FAQ |
 
 ## Email

--- a/docs/how-to/organise/create-inbox-rules.md
+++ b/docs/how-to/organise/create-inbox-rules.md
@@ -80,11 +80,31 @@ params:
   sequence: 1
 ```
 
+## Delete a Rule
+
+> "Delete the GitHub Notifications rule"
+
+```
+tool: manage-rules
+params:
+  action: "delete"
+  ruleName: "GitHub Notifications"
+```
+
+You can also delete by ID:
+
+```
+tool: manage-rules
+params:
+  action: "delete"
+  ruleId: "rule-id..."
+```
+
 ## Parameter Reference
 
 | Parameter | What it does | Used with |
 |-----------|-------------|-----------|
-| `action` | `list`, `create`, or `reorder` | All |
+| `action` | `list`, `create`, `reorder`, or `delete` | All |
 | `includeDetails` | Show full conditions/actions | `list` |
 | `name` | Rule name | `create` |
 | `fromAddresses` | Sender email addresses (comma-separated) | `create` |
@@ -94,7 +114,8 @@ params:
 | `markAsRead` | Auto-mark as read | `create` |
 | `isEnabled` | Enable rule after creation (default: true) | `create` |
 | `sequence` | Execution order — lower runs first (default: 100) | `create`, `reorder` |
-| `ruleName` | Rule to reorder | `reorder` |
+| `ruleName` | Rule name | `reorder`, `delete` |
+| `ruleId` | Rule ID | `delete` |
 
 ## Tips
 

--- a/docs/how-to/organise/organise-with-folders.md
+++ b/docs/how-to/organise/organise-with-folders.md
@@ -95,11 +95,33 @@ params:
 
 This returns total items, unread count, and folder size — useful for planning pagination or understanding email volume.
 
+## Delete a Folder
+
+> "Delete the old Project Alpha folder"
+
+```
+tool: folders
+params:
+  action: "delete"
+  folderName: "Project Alpha"
+```
+
+You can also delete by ID:
+
+```
+tool: folders
+params:
+  action: "delete"
+  folderId: "AAMkAGR..."
+```
+
+Protected folders (Inbox, Drafts, Sent Items, Deleted Items, Junk Email, Archive, Outbox) cannot be deleted.
+
 ## Parameter Reference
 
 | Parameter | What it does | Used with |
 |-----------|-------------|-----------|
-| `action` | `list`, `create`, `move`, or `stats` | All |
+| `action` | `list`, `create`, `move`, `stats`, or `delete` | All |
 | `includeItemCounts` | Show total/unread counts | `list` |
 | `includeChildren` | Show nested subfolders | `list` |
 | `name` | New folder name | `create` |
@@ -108,6 +130,8 @@ This returns total items, unread count, and folder size — useful for planning 
 | `targetFolder` | Destination folder name | `move` |
 | `sourceFolder` | Source folder (default: inbox) | `move` |
 | `folder` | Folder to get stats for | `stats` |
+| `folderId` | Folder ID to delete | `delete` |
+| `folderName` | Folder name to delete (resolved to ID) | `delete` |
 
 ## Tips
 

--- a/docs/how-to/settings/set-out-of-office.md
+++ b/docs/how-to/settings/set-out-of-office.md
@@ -108,6 +108,7 @@ This shows whether auto-replies are enabled, the schedule, and the current messa
 - Include `startDateTime` and `endDateTime` for scheduled auto-activate/deactivate
 - You can include HTML in your reply messages for formatting
 - Check your current status with `action: "get"` before making changes
+- If you enable auto-replies without providing a message, the server warns you — it will note if a previously configured message will be reused, or warn that recipients will receive a blank reply
 
 ## Related
 

--- a/docs/quickrefs/tools-reference.md
+++ b/docs/quickrefs/tools-reference.md
@@ -69,13 +69,13 @@ Quick reference for all 20 consolidated MCP tools across 9 modules. Each tool in
 
 | Tool | Actions | Safety | Key Parameters |
 |------|---------|--------|----------------|
-| `folders` | `list` (default), `create`, `move`, `stats` | moderate write | `name`, `emailIds`, `targetFolder`, `folder`, `outputVerbosity` |
+| `folders` | `list` (default), `create`, `move`, `stats`, `delete` | **destructive** | `name`, `emailIds`, `targetFolder`, `folder`, `folderId`, `folderName`, `outputVerbosity` |
 
 ## Rules (1 tool)
 
 | Tool | Actions | Safety | Key Parameters |
 |------|---------|--------|----------------|
-| `manage-rules` | `list` (default), `create`, `reorder` | moderate write | `name`, `fromAddresses`, `moveToFolder`, `ruleName`, `sequence` |
+| `manage-rules` | `list` (default), `create`, `reorder`, `delete` | **destructive** | `name`, `fromAddresses`, `moveToFolder`, `ruleName`, `ruleId`, `sequence` |
 
 ## Contacts (2 tools)
 
@@ -113,10 +113,10 @@ Quick reference for all 20 consolidated MCP tools across 9 modules. Each tool in
 
 | Category | Tools | Client Behaviour |
 |----------|-------|------------------|
-| **Read-only** (6) | `search-emails`, `read-email`, `list-events`, `search-people`, `access-shared-mailbox`, `find-meeting-rooms` | Auto-approved by Claude Code |
-| **Destructive** (2) | `send-email`, `manage-event` | Claude prompts for confirmation |
+| **Read-only** (6) | `search-emails`, `read-email`, `list-events`, `search-people`, `access-shared-mailbox`, `find-meeting-rooms` | Auto-approved by MCP clients that support annotations |
+| **Destructive** (4) | `send-email`, `manage-event`, `folders`, `manage-rules` | Client prompts for confirmation |
 | **Idempotent** (2) | `update-email`, `mailbox-settings` | Safe to retry |
-| **Moderate write** (9) | All others | Normal approval flow |
+| **Moderate write** (7) | All others | Normal approval flow |
 
 ## send-email Safety Controls
 

--- a/docs/testing-notes.md
+++ b/docs/testing-notes.md
@@ -1,5 +1,88 @@
 # Outlook MCP Tool Testing Notes
 
+## v3.1.0 Comprehensive Retest #2 — COMPLETE
+
+**Date**: 2026-03-05
+**Server Version**: 3.1.0
+**Tester**: Claude Code (via live MCP calls)
+**Account**: Personal Microsoft account (nathanschram@live.com)
+**Purpose**: Fresh comprehensive retest of all 20 tools — happy paths, edge cases, and cross-cutting concerns
+
+### Result: 20/20 tools PASS — 7 bugs, 6 enhancements filed
+
+All 20 tools tested with multiple scenarios each. No crashes or regressions. 13 GitHub issues created (#46-#58).
+
+### Pre-test Fixes Applied
+- Auth server env var priority: `OUTLOOK_*` now checked before `MS_*` (3 source files, 2 test files)
+- Auth pages and 16 documentation files made agent-agnostic ("your AI assistant" not "Claude")
+
+### Results by Module
+
+| Module | Tool | Status | Issues |
+|--------|------|--------|--------|
+| Auth | `auth` | PASS | #53 (enhancement) |
+| Email | `search-emails` | PASS | #46 (bug), #47 (bug) |
+| Email | `read-email` | PASS | #48 (bug) |
+| Email | `send-email` | PASS | #49 (bug) |
+| Email | `update-email` | PASS | — |
+| Email | `attachments` | PASS | — |
+| Email | `export` | PASS | #50 (bug) |
+| Calendar | `list-events` | PASS | #51 (bug) |
+| Calendar | `create-event` | PASS | — |
+| Calendar | `manage-event` | PASS | — |
+| Folder | `folders` | PASS | #54 (enhancement) |
+| Rules | `manage-rules` | PASS | #52 (bug), #55 (enhancement) |
+| Contacts | `manage-contact` | PASS | #56 (enhancement) |
+| Contacts | `search-people` | PASS | — |
+| Categories | `manage-category` | PASS | — |
+| Categories | `apply-category` | PASS | — |
+| Categories | `manage-focused-inbox` | PASS | — |
+| Settings | `mailbox-settings` | PASS | #57 (enhancement), #58 (enhancement) |
+| Advanced | `access-shared-mailbox` | PASS (graceful error) | — |
+| Advanced | `find-meeting-rooms` | PASS (graceful error) | — |
+
+### Bugs Found (#46-#52)
+
+| Issue | Tool | Summary |
+|-------|------|---------|
+| #46 | `search-emails` | Nonexistent folder silently falls back to inbox |
+| #47 | `search-emails` | `count=0` returns all emails instead of error |
+| #48 | `read-email` | Minimal verbosity shows "No content" and blank To |
+| #49 | `send-email` | HTML body Content-Type shows "text" not "HTML" |
+| #50 | `export` | Conversation export raw API error on personal accounts |
+| #51 | `list-events` | Times displayed in UTC not configured local timezone |
+| #52 | `manage-rules` | Sequence display shows positional number not actual value |
+
+### Enhancements Filed (#53-#58)
+
+| Issue | Tool | Summary |
+|-------|------|---------|
+| #53 | `auth` | `about` action could show tool count, scopes, capabilities |
+| #54 | `folders` | Add `action=delete` for folder removal |
+| #55 | `manage-rules` | Add `action=delete` for rule removal |
+| #56 | `manage-contact` | Minimal verbosity identical to standard |
+| #57 | `mailbox-settings` | Section-specific `get` returns raw JSON vs formatted markdown |
+| #58 | `mailbox-settings` | `set-auto-replies` without message reuses previous silently |
+
+### Test Coverage Notes
+
+- **send-email**: Tested with `dryRun=true` only (no live sends)
+- **access-shared-mailbox**: Graceful error — requires org shared mailbox
+- **find-meeting-rooms**: Graceful error — requires org-configured rooms + Places.Read.All
+- **manage-event decline/cancel**: Tested delete only; decline/cancel need events from other organiser
+- All test data cleaned up (calendar events, contacts, categories, focused inbox overrides, folders, rules)
+- `set-auto-replies` and `set-working-hours` tested and restored to original values
+
+### Cross-Cutting Observations
+
+1. **Response formatting**: Generally excellent markdown. Inconsistency in `mailbox-settings` section-specific views (raw JSON vs formatted)
+2. **Error messages**: Most tools return helpful errors. `search-emails` silently falls back on invalid folder (worst case). `export` conversation shows raw API error on personal accounts
+3. **Parameter validation**: `count=0` not validated. Invalid section name passes through to API. Most required params validated well
+4. **Destructive tools**: Properly marked and confirmation-gated
+5. **Verbosity levels**: Work well for `search-emails` and `read-email`; `manage-contact` minimal = standard (no differentiation)
+
+---
+
 ## v3.1.0 Retest — COMPLETE
 
 **Date**: 2026-03-04

--- a/email/conversations.js
+++ b/email/conversations.js
@@ -215,13 +215,32 @@ async function handleGetConversation(args) {
       $top: 100,
     };
 
-    const response = await callGraphAPI(
-      accessToken,
-      'GET',
-      endpoint,
-      null,
-      queryParams
-    );
+    let response;
+    try {
+      response = await callGraphAPI(
+        accessToken,
+        'GET',
+        endpoint,
+        null,
+        queryParams
+      );
+    } catch (apiError) {
+      if (
+        apiError.message.includes('ErrorInvalidUrlQueryFilter') ||
+        apiError.message.includes('InefficientFilter') ||
+        apiError.message.includes('filter')
+      ) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Conversation retrieval by conversationId is not supported on personal Microsoft accounts. Use read-email with individual message IDs instead.`,
+            },
+          ],
+        };
+      }
+      throw apiError;
+    }
     const messages = response.value || [];
 
     if (messages.length === 0) {
@@ -335,13 +354,32 @@ async function handleExportConversation(args) {
       $top: 100,
     };
 
-    const response = await callGraphAPI(
-      accessToken,
-      'GET',
-      endpoint,
-      null,
-      queryParams
-    );
+    let response;
+    try {
+      response = await callGraphAPI(
+        accessToken,
+        'GET',
+        endpoint,
+        null,
+        queryParams
+      );
+    } catch (apiError) {
+      if (
+        apiError.message.includes('ErrorInvalidUrlQueryFilter') ||
+        apiError.message.includes('InefficientFilter') ||
+        apiError.message.includes('filter')
+      ) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Conversation export is not supported on personal Microsoft accounts. Use export with target=message and individual message IDs instead.`,
+            },
+          ],
+        };
+      }
+      throw apiError;
+    }
     const messages = response.value || [];
 
     if (messages.length === 0) {

--- a/email/folder-utils.js
+++ b/email/folder-utils.js
@@ -49,14 +49,17 @@ async function resolveFolderPath(accessToken, folderName) {
       return path;
     }
 
-    // If not found, fall back to inbox
-    console.error(
-      `Couldn't find folder "${folderName}", falling back to inbox`
+    // If not found, throw error instead of silently falling back
+    throw new Error(
+      `Folder "${folderName}" not found. Use the folders tool (action=list) to see available folders.`
     );
-    return WELL_KNOWN_FOLDERS['inbox'];
   } catch (error) {
-    console.error(`Error resolving folder "${folderName}": ${error.message}`);
-    return WELL_KNOWN_FOLDERS['inbox'];
+    if (error.message.includes('not found')) {
+      throw error;
+    }
+    throw new Error(
+      `Error resolving folder "${folderName}": ${error.message}. Use the folders tool (action=list) to see available folders.`
+    );
   }
 }
 

--- a/email/read.js
+++ b/email/read.js
@@ -24,7 +24,7 @@ function getReadFieldPreset(verbosity, includeHeaders) {
   }
   switch (verbosity) {
     case VERBOSITY.MINIMAL:
-      return 'list'; // Basic fields only
+      return 'read-minimal'; // Includes bodyPreview + toRecipients
     case VERBOSITY.FULL:
       return 'read'; // Full read fields
     case VERBOSITY.STANDARD:

--- a/email/search.js
+++ b/email/search.js
@@ -25,7 +25,15 @@ const { getEmailFields } = require('../utils/field-presets');
  */
 async function handleSearchEmails(args) {
   const folder = args.folder || 'inbox';
-  const requestedCount = args.count || DEFAULT_LIMITS.searchEmails; // Default 10
+
+  // Validate count
+  if (args.count !== undefined && args.count < 1) {
+    return {
+      content: [{ type: 'text', text: 'count must be at least 1.' }],
+    };
+  }
+
+  const requestedCount = args.count ?? DEFAULT_LIMITS.searchEmails; // Default 10
   const verbosity = args.outputVerbosity || VERBOSITY.STANDARD;
   const query = args.query || '';
   const from = args.from || '';

--- a/email/send.js
+++ b/email/send.js
@@ -104,7 +104,12 @@ async function handleSendEmail(args) {
       message: {
         subject,
         body: {
-          contentType: body.includes('<html') ? 'html' : 'text',
+          contentType:
+            /<(html|div|p|h[1-6]|br|table|ul|ol|li|span|a\s|img|strong|em|b|i)\b/i.test(
+              body
+            )
+              ? 'html'
+              : 'text',
           content: body,
         },
         toRecipients,

--- a/folder/delete.js
+++ b/folder/delete.js
@@ -1,0 +1,108 @@
+/**
+ * Delete folder functionality
+ */
+const { callGraphAPI } = require('../utils/graph-api');
+const { ensureAuthenticated } = require('../auth');
+const { getFolderIdByName } = require('../email/folder-utils');
+
+/**
+ * Protected folder names that cannot be deleted
+ */
+const PROTECTED_FOLDERS = [
+  'inbox',
+  'drafts',
+  'sentitems',
+  'deleteditems',
+  'junkemail',
+  'archive',
+  'outbox',
+];
+
+/**
+ * Delete folder handler
+ * @param {object} args - Tool arguments
+ * @param {string} [args.folderId] - Folder ID to delete
+ * @param {string} [args.folderName] - Folder name to delete (resolved to ID)
+ * @returns {object} - MCP response
+ */
+async function handleDeleteFolder(args) {
+  const { folderId, folderName } = args;
+
+  if (!folderId && !folderName) {
+    return {
+      content: [
+        {
+          type: 'text',
+          text: 'Either folderId or folderName is required.',
+        },
+      ],
+    };
+  }
+
+  // Guard against deleting protected folders
+  if (folderName && PROTECTED_FOLDERS.includes(folderName.toLowerCase())) {
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `Cannot delete protected folder "${folderName}". Protected folders: Inbox, Drafts, Sent Items, Deleted Items, Junk Email, Archive, Outbox.`,
+        },
+      ],
+    };
+  }
+
+  try {
+    const accessToken = await ensureAuthenticated();
+
+    let resolvedId = folderId;
+
+    // Resolve folder name to ID if needed
+    if (!resolvedId && folderName) {
+      resolvedId = await getFolderIdByName(accessToken, folderName);
+      if (!resolvedId) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Folder "${folderName}" not found. Use folders (action=list) to see available folders.`,
+            },
+          ],
+        };
+      }
+    }
+
+    // Delete the folder
+    await callGraphAPI(accessToken, 'DELETE', `me/mailFolders/${resolvedId}`);
+
+    const displayName = folderName || resolvedId;
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `Folder "${displayName}" deleted successfully.`,
+        },
+      ],
+    };
+  } catch (error) {
+    if (error.message === 'Authentication required') {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: "Authentication required. Please use the 'auth' tool with action=authenticate first.",
+          },
+        ],
+      };
+    }
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `Error deleting folder: ${error.message}`,
+        },
+      ],
+    };
+  }
+}
+
+module.exports = handleDeleteFolder;

--- a/folder/index.js
+++ b/folder/index.js
@@ -5,17 +5,18 @@ const handleListFolders = require('./list');
 const handleCreateFolder = require('./create');
 const handleMoveEmails = require('./move');
 const handleGetFolderStats = require('./stats');
+const handleDeleteFolder = require('./delete');
 
 // Consolidated folder tool definition
 const folderTools = [
   {
     name: 'folders',
     description:
-      'Manage mail folders. action=list (default) lists folders. action=create creates a folder. action=move moves emails between folders. action=stats gets folder counts for pagination planning.',
+      'Manage mail folders. action=list (default) lists folders. action=create creates a folder. action=move moves emails between folders. action=stats gets folder counts for pagination planning. action=delete removes a folder.',
     annotations: {
       title: 'Mail Folders',
       readOnlyHint: false,
-      destructiveHint: false,
+      destructiveHint: true,
       openWorldHint: false,
     },
     inputSchema: {
@@ -23,7 +24,7 @@ const folderTools = [
       properties: {
         action: {
           type: 'string',
-          enum: ['list', 'create', 'move', 'stats'],
+          enum: ['list', 'create', 'move', 'stats', 'delete'],
           description: 'Action to perform (default: list)',
         },
         // list params
@@ -69,6 +70,16 @@ const folderTools = [
           enum: ['minimal', 'standard', 'full'],
           description: 'Output detail level (action=stats, default: standard)',
         },
+        // delete params
+        folderId: {
+          type: 'string',
+          description: 'Folder ID to delete (action=delete)',
+        },
+        folderName: {
+          type: 'string',
+          description:
+            'Folder name to delete — resolved to ID (action=delete). Cannot delete protected folders (Inbox, Drafts, Sent, etc.)',
+        },
       },
       required: [],
     },
@@ -81,6 +92,8 @@ const folderTools = [
           return handleMoveEmails(args);
         case 'stats':
           return handleGetFolderStats(args);
+        case 'delete':
+          return handleDeleteFolder(args);
         case 'list':
         default:
           return handleListFolders(args);
@@ -95,4 +108,5 @@ module.exports = {
   handleCreateFolder,
   handleMoveEmails,
   handleGetFolderStats,
+  handleDeleteFolder,
 };

--- a/outlook-auth-server.js
+++ b/outlook-auth-server.js
@@ -16,9 +16,9 @@ console.log('Starting Outlook Authentication Server');
 
 // Authentication configuration — scopes and tokenStorePath from config.js (single source of truth)
 const AUTH_CONFIG = {
-  clientId: process.env.MS_CLIENT_ID || process.env.OUTLOOK_CLIENT_ID || '',
+  clientId: process.env.OUTLOOK_CLIENT_ID || process.env.MS_CLIENT_ID || '',
   clientSecret:
-    process.env.MS_CLIENT_SECRET || process.env.OUTLOOK_CLIENT_SECRET || '',
+    process.env.OUTLOOK_CLIENT_SECRET || process.env.MS_CLIENT_SECRET || '',
   redirectUri: centralAuth.redirectUri,
   scopes: centralAuth.scopes,
   tokenStorePath: centralAuth.tokenStorePath,
@@ -86,7 +86,7 @@ const server = http.createServer((req, res) => {
                   <p>You have successfully authenticated with Microsoft Graph API.</p>
                   <p>The access token has been saved securely.</p>
                 </div>
-                <p>You can now close this window and return to Claude.</p>
+                <p>You can now close this window and return to your AI assistant.</p>
               </body>
             </html>
           `);
@@ -160,9 +160,10 @@ const server = http.createServer((req, res) => {
             <div class="error-box">
               <p>Microsoft Graph API credentials are not set. Please set the following environment variables:</p>
               <ul>
-                <li><code>MS_CLIENT_ID</code></li>
-                <li><code>MS_CLIENT_SECRET</code></li>
+                <li><code>OUTLOOK_CLIENT_ID</code></li>
+                <li><code>OUTLOOK_CLIENT_SECRET</code></li>
               </ul>
+              <p style="margin-top: 10px; font-size: 0.9em; color: #666;">Legacy names <code>MS_CLIENT_ID</code> / <code>MS_CLIENT_SECRET</code> are also accepted.</p>
             </div>
           </body>
         </html>
@@ -208,8 +209,8 @@ const server = http.createServer((req, res) => {
           <h1>Outlook Authentication Server</h1>
           <div class="info-box">
             <p>This server is running to handle Microsoft Graph API authentication callbacks.</p>
-            <p>Don't navigate here directly. Instead, use the <code>authenticate</code> tool in Claude to start the authentication process.</p>
-            <p>Make sure you've set the <code>MS_CLIENT_ID</code> and <code>MS_CLIENT_SECRET</code> environment variables.</p>
+            <p>Don't navigate here directly. Instead, use the <code>auth</code> tool (with <code>action=authenticate</code>) in your AI assistant to start the authentication process.</p>
+            <p>Make sure you've set the <code>OUTLOOK_CLIENT_ID</code> and <code>OUTLOOK_CLIENT_SECRET</code> environment variables.</p>
           </div>
           <p>Server is running at http://localhost:3333</p>
         </body>
@@ -304,7 +305,7 @@ server.listen(PORT, '127.0.0.1', () => {
   if (!AUTH_CONFIG.clientId || !AUTH_CONFIG.clientSecret) {
     console.log('\n⚠️  WARNING: Microsoft Graph API credentials are not set.');
     console.log(
-      '   Please set the MS_CLIENT_ID and MS_CLIENT_SECRET environment variables.'
+      '   Please set the OUTLOOK_CLIENT_ID and OUTLOOK_CLIENT_SECRET environment variables.'
     );
   }
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@littlebearapps/outlook-mcp",
-  "version": "3.0.0",
+  "version": "3.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@littlebearapps/outlook-mcp",
-      "version": "3.0.0",
+      "version": "3.2.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.1.0",
@@ -1084,9 +1084,9 @@
       "license": "MIT"
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.9",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
-      "integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
+      "version": "1.19.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
+      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -6162,9 +6162,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.2",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.2.tgz",
-      "integrity": "sha512-gJnaDHXKDayjt8ue0n8Gs0A007yKXj4Xzb8+cNjZeYsSzzwKc0Lr+OZgYwVfB0pHfUs17EPoLvrOsEaJ9mj+Tg==",
+      "version": "4.12.5",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.5.tgz",
+      "integrity": "sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@littlebearapps/outlook-mcp",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "MCP server for Claude to access Outlook data via Microsoft Graph API",
   "main": "index.js",
   "bin": {

--- a/rules/index.js
+++ b/rules/index.js
@@ -7,6 +7,85 @@ const { callGraphAPI } = require('../utils/graph-api');
 const { ensureAuthenticated } = require('../auth');
 
 /**
+ * Delete rule handler
+ * @param {object} args - Tool arguments
+ * @returns {object} - MCP response
+ */
+async function handleDeleteRule(args) {
+  const { ruleName, ruleId } = args;
+
+  if (!ruleName && !ruleId) {
+    return {
+      content: [
+        {
+          type: 'text',
+          text: 'Either ruleName or ruleId is required.',
+        },
+      ],
+    };
+  }
+
+  try {
+    const accessToken = await ensureAuthenticated();
+
+    let resolvedId = ruleId;
+    let displayName = ruleId;
+
+    // Resolve name to ID if needed
+    if (!resolvedId && ruleName) {
+      const rules = await getInboxRules(accessToken);
+      const rule = rules.find((r) => r.displayName === ruleName);
+      if (!rule) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Rule with name "${ruleName}" not found.`,
+            },
+          ],
+        };
+      }
+      resolvedId = rule.id;
+      displayName = ruleName;
+    }
+
+    await callGraphAPI(
+      accessToken,
+      'DELETE',
+      `me/mailFolders/inbox/messageRules/${resolvedId}`
+    );
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `Successfully deleted rule "${displayName}".`,
+        },
+      ],
+    };
+  } catch (error) {
+    if (error.message === 'Authentication required') {
+      return {
+        content: [
+          {
+            type: 'text',
+            text: "Authentication required. Please use the 'auth' tool with action=authenticate first.",
+          },
+        ],
+      };
+    }
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `Error deleting rule: ${error.message}`,
+        },
+      ],
+    };
+  }
+}
+
+/**
  * Edit rule sequence handler
  * @param {object} args - Tool arguments
  * @returns {object} - MCP response
@@ -102,11 +181,11 @@ const rulesTools = [
   {
     name: 'manage-rules',
     description:
-      'Manage inbox rules. action=list (default) lists rules. action=create creates a new rule. action=reorder changes rule execution priority.',
+      'Manage inbox rules. action=list (default) lists rules. action=create creates a new rule. action=reorder changes rule execution priority. action=delete removes a rule.',
     annotations: {
       title: 'Inbox Rules',
       readOnlyHint: false,
-      destructiveHint: false,
+      destructiveHint: true,
       openWorldHint: false,
     },
     inputSchema: {
@@ -114,7 +193,7 @@ const rulesTools = [
       properties: {
         action: {
           type: 'string',
-          enum: ['list', 'create', 'reorder'],
+          enum: ['list', 'create', 'reorder', 'delete'],
           description: 'Action to perform (default: list)',
         },
         // list params
@@ -161,7 +240,12 @@ const rulesTools = [
         // reorder params
         ruleName: {
           type: 'string',
-          description: 'Name of the rule to reorder (action=reorder, required)',
+          description:
+            'Name of the rule (action=reorder required, action=delete alternative to ruleId)',
+        },
+        ruleId: {
+          type: 'string',
+          description: 'ID of the rule to delete (action=delete)',
         },
       },
       required: [],
@@ -173,6 +257,8 @@ const rulesTools = [
           return handleCreateRule(args);
         case 'reorder':
           return handleEditRuleSequence(args);
+        case 'delete':
+          return handleDeleteRule(args);
         case 'list':
         default:
           return handleListRules(args);
@@ -186,4 +272,5 @@ module.exports = {
   handleListRules,
   handleCreateRule,
   handleEditRuleSequence,
+  handleDeleteRule,
 };

--- a/rules/list.js
+++ b/rules/list.js
@@ -93,9 +93,9 @@ function formatRulesList(rules, includeDetails) {
   // Format rules based on detail level
   if (includeDetails) {
     // Detailed format
-    const detailedRules = sortedRules.map((rule, index) => {
+    const detailedRules = sortedRules.map((rule) => {
       // Format rule header with sequence
-      let ruleText = `${index + 1}. ${rule.displayName}${rule.isEnabled ? '' : ' (Disabled)'} - Sequence: ${rule.sequence || 'N/A'}`;
+      let ruleText = `[${rule.sequence || 'N/A'}] ${rule.displayName}${rule.isEnabled ? '' : ' (Disabled)'}`;
 
       // Format conditions
       const conditions = formatRuleConditions(rule);
@@ -115,8 +115,8 @@ function formatRulesList(rules, includeDetails) {
     return `Found ${rules.length} inbox rules (sorted by execution order):\n\n${detailedRules.join('\n\n')}\n\nRules are processed in order of their sequence number. You can change rule order using manage-rules with action=reorder.`;
   } else {
     // Simple format
-    const simpleRules = sortedRules.map((rule, index) => {
-      return `${index + 1}. ${rule.displayName}${rule.isEnabled ? '' : ' (Disabled)'} - Sequence: ${rule.sequence || 'N/A'}`;
+    const simpleRules = sortedRules.map((rule) => {
+      return `[${rule.sequence || 'N/A'}] ${rule.displayName}${rule.isEnabled ? '' : ' (Disabled)'}`;
     });
 
     return `Found ${rules.length} inbox rules (sorted by execution order):\n\n${simpleRules.join('\n')}\n\nTip: Use 'list-rules with includeDetails=true' to see more information about each rule.`;

--- a/settings/index.js
+++ b/settings/index.js
@@ -117,11 +117,25 @@ async function handleGetMailboxSettings(args) {
     output.push('# Mailbox Settings\n');
 
     if (section && section !== 'all') {
-      // Single section
-      output.push(`## ${section.charAt(0).toUpperCase() + section.slice(1)}\n`);
-      output.push('```json');
-      output.push(JSON.stringify(settings, null, 2));
-      output.push('```');
+      // Single section — format based on section type
+      const sectionTitle = section.charAt(0).toUpperCase() + section.slice(1);
+      output.push(`## ${sectionTitle}\n`);
+
+      if (section === 'workingHours') {
+        output.push(formatWorkingHours(settings));
+      } else if (section === 'automaticRepliesSetting') {
+        output.push(formatAutomaticReplies(settings));
+      } else if (section === 'language') {
+        output.push(`**Locale**: ${settings.locale || 'Not set'}`);
+        output.push(`**Display Name**: ${settings.displayName || 'Not set'}`);
+      } else if (section === 'timeZone') {
+        output.push(`**Zone**: ${settings}`);
+      } else {
+        // Fallback for unknown sections
+        output.push('```json');
+        output.push(JSON.stringify(settings, null, 2));
+        output.push('```');
+      }
     } else {
       // All settings
       if (settings.language) {
@@ -274,6 +288,26 @@ async function handleSetAutomaticReplies(args) {
     let output = [];
     output.push('Automatic replies updated!\n');
     output.push(formatAutomaticReplies(updated));
+
+    // Warn if enabling without messages
+    if (
+      updated.status !== 'disabled' &&
+      !internalReplyMessage &&
+      !externalReplyMessage
+    ) {
+      if (updated.internalReplyMessage || updated.externalReplyMessage) {
+        const preview = (
+          updated.internalReplyMessage || updated.externalReplyMessage
+        ).substring(0, 100);
+        output.push(
+          `\n**Note**: Using previously configured message: "${preview}${preview.length >= 100 ? '...' : ''}"`
+        );
+      } else {
+        output.push(
+          '\n**Warning**: Auto-replies enabled with no message configured. Recipients will receive a blank reply.'
+        );
+      }
+    }
 
     return {
       content: [

--- a/test/auth/oauth-server.test.js
+++ b/test/auth/oauth-server.test.js
@@ -290,9 +290,16 @@ describe('OAuth Server Routes', () => {
       expect(config.authEndpoint).toBe('http://env.auth/endpoint');
     });
 
-    it('should use default "MS_" prefix if none provided', () => {
+    it('should use default "OUTLOOK_" prefix if none provided', () => {
+      process.env.OUTLOOK_CLIENT_ID = 'outlook_client_id_val';
+      const config = createAuthConfig(); // No prefix, defaults to OUTLOOK_
+      expect(config.clientId).toBe('outlook_client_id_val');
+    });
+
+    it('should fall back to MS_ prefix for backwards compatibility', () => {
+      delete process.env.OUTLOOK_CLIENT_ID;
       process.env.MS_CLIENT_ID = 'ms_client_id_val';
-      const config = createAuthConfig(); // No prefix, defaults to MS_
+      const config = createAuthConfig(); // Should fall back to MS_CLIENT_ID
       expect(config.clientId).toBe('ms_client_id_val');
     });
   });

--- a/test/auth/token-storage.test.js
+++ b/test/auth/token-storage.test.js
@@ -54,7 +54,7 @@ describe('TokenStorage', () => {
       const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
       new TokenStorage({ ...baseConfig, clientId: null });
       expect(consoleWarnSpy).toHaveBeenCalledWith(
-        'TokenStorage: MS_CLIENT_ID or MS_CLIENT_SECRET is not configured. Token operations might fail.'
+        'TokenStorage: OUTLOOK_CLIENT_ID or OUTLOOK_CLIENT_SECRET is not configured. Token operations might fail.'
       );
       consoleWarnSpy.mockRestore();
     });

--- a/test/email/folder-utils.test.js
+++ b/test/email/folder-utils.test.js
@@ -99,7 +99,7 @@ describe('resolveFolderPath', () => {
       expect(callGraphAPI).toHaveBeenCalledTimes(2);
     });
 
-    test('should fall back to inbox when custom folder is not found', async () => {
+    test('should throw error when custom folder is not found', async () => {
       const nonExistentFolder = 'NonExistentFolder';
 
       // First call returns empty (exact match fails)
@@ -113,23 +113,20 @@ describe('resolveFolderPath', () => {
         ],
       });
 
-      const result = await resolveFolderPath(
-        mockAccessToken,
-        nonExistentFolder
-      );
-
-      expect(result).toBe(WELL_KNOWN_FOLDERS['inbox']);
+      await expect(
+        resolveFolderPath(mockAccessToken, nonExistentFolder)
+      ).rejects.toThrow('not found');
       expect(callGraphAPI).toHaveBeenCalledTimes(2);
     });
 
-    test('should fall back to inbox when API call fails', async () => {
+    test('should throw error when API call fails', async () => {
       const customFolderName = 'CustomFolder';
 
       callGraphAPI.mockRejectedValueOnce(new Error('API Error'));
 
-      const result = await resolveFolderPath(mockAccessToken, customFolderName);
-
-      expect(result).toBe(WELL_KNOWN_FOLDERS['inbox']);
+      await expect(
+        resolveFolderPath(mockAccessToken, customFolderName)
+      ).rejects.toThrow('not found');
       expect(callGraphAPI).toHaveBeenCalledTimes(1);
     });
   });

--- a/test/rules/rules.test.js
+++ b/test/rules/rules.test.js
@@ -1,6 +1,6 @@
 const { handleListRules } = require('../../rules/list');
 const handleCreateRule = require('../../rules/create');
-const { handleEditRuleSequence } = require('../../rules');
+const { handleEditRuleSequence, handleDeleteRule } = require('../../rules');
 const { callGraphAPI } = require('../../utils/graph-api');
 const { ensureAuthenticated } = require('../../auth');
 const { getFolderIdByName } = require('../../email/folder-utils');
@@ -292,5 +292,58 @@ describe('handleEditRuleSequence', () => {
     expect(result.content[0].text).toBe(
       'Error updating rule sequence: Update failed'
     );
+  });
+});
+
+describe('handleDeleteRule', () => {
+  it('should delete a rule by name', async () => {
+    // getInboxRules call
+    callGraphAPI.mockResolvedValueOnce({ value: mockRules });
+    // DELETE call
+    callGraphAPI.mockResolvedValueOnce({});
+
+    const result = await handleDeleteRule({ ruleName: 'Move newsletters' });
+
+    expect(result.content[0].text).toContain('Successfully deleted');
+    expect(result.content[0].text).toContain('Move newsletters');
+  });
+
+  it('should delete a rule by ID', async () => {
+    callGraphAPI.mockResolvedValueOnce({});
+
+    const result = await handleDeleteRule({ ruleId: 'rule-1' });
+
+    expect(result.content[0].text).toContain('Successfully deleted');
+  });
+
+  it('should require ruleName or ruleId', async () => {
+    const result = await handleDeleteRule({});
+
+    expect(result.content[0].text).toContain('Either ruleName or ruleId');
+  });
+
+  it('should handle rule not found', async () => {
+    callGraphAPI.mockResolvedValue({ value: mockRules });
+
+    const result = await handleDeleteRule({ ruleName: 'NonExistent' });
+
+    expect(result.content[0].text).toContain('not found');
+  });
+
+  it('should handle auth error', async () => {
+    ensureAuthenticated.mockRejectedValue(new Error('Authentication required'));
+
+    const result = await handleDeleteRule({ ruleName: 'Test' });
+
+    expect(result.content[0].text).toContain('Authentication required');
+  });
+
+  it('should handle API error', async () => {
+    callGraphAPI.mockResolvedValueOnce({ value: mockRules });
+    callGraphAPI.mockRejectedValueOnce(new Error('Delete failed'));
+
+    const result = await handleDeleteRule({ ruleName: 'Move newsletters' });
+
+    expect(result.content[0].text).toBe('Error deleting rule: Delete failed');
   });
 });

--- a/test/settings/settings.test.js
+++ b/test/settings/settings.test.js
@@ -55,12 +55,56 @@ describe('handleGetMailboxSettings', () => {
   });
 
   it('should return specific section when requested', async () => {
-    callGraphAPI.mockResolvedValue({ locale: 'en-AU' });
+    callGraphAPI.mockResolvedValue({
+      locale: 'en-AU',
+      displayName: 'English (Australia)',
+    });
 
     const result = await handleGetMailboxSettings({ section: 'language' });
 
     expect(result.content[0].text).toContain('Language');
     expect(result.content[0].text).toContain('en-AU');
+    // Should be formatted, not raw JSON
+    expect(result.content[0].text).not.toContain('```json');
+  });
+
+  it('should format workingHours section', async () => {
+    callGraphAPI.mockResolvedValue({
+      startTime: '09:00:00.0000000',
+      endTime: '17:00:00.0000000',
+      daysOfWeek: ['monday', 'tuesday', 'wednesday', 'thursday', 'friday'],
+      timeZone: { name: 'AUS Eastern Standard Time' },
+    });
+
+    const result = await handleGetMailboxSettings({
+      section: 'workingHours',
+    });
+
+    expect(result.content[0].text).toContain('09:00');
+    expect(result.content[0].text).toContain('17:00');
+    expect(result.content[0].text).not.toContain('```json');
+  });
+
+  it('should format automaticRepliesSetting section', async () => {
+    callGraphAPI.mockResolvedValue({
+      status: 'disabled',
+    });
+
+    const result = await handleGetMailboxSettings({
+      section: 'automaticRepliesSetting',
+    });
+
+    expect(result.content[0].text).toContain('Disabled');
+    expect(result.content[0].text).not.toContain('```json');
+  });
+
+  it('should format timeZone section', async () => {
+    callGraphAPI.mockResolvedValue('AUS Eastern Standard Time');
+
+    const result = await handleGetMailboxSettings({ section: 'timeZone' });
+
+    expect(result.content[0].text).toContain('AUS Eastern Standard Time');
+    expect(result.content[0].text).not.toContain('```json');
   });
 
   it('should treat section "all" same as no section', async () => {
@@ -232,6 +276,51 @@ describe('handleSetAutomaticReplies', () => {
 
     expect(result.content[0].text).toContain('updated');
     expect(result.content[0].text).toContain('Scheduled');
+  });
+
+  it('should warn when enabling without messages and no existing messages', async () => {
+    callGraphAPI
+      .mockResolvedValueOnce({}) // PATCH
+      .mockResolvedValueOnce({
+        status: 'alwaysEnabled',
+      }); // GET updated — no messages
+
+    const result = await handleSetAutomaticReplies({ enabled: true });
+
+    expect(result.content[0].text).toContain('Warning');
+    expect(result.content[0].text).toContain('no message configured');
+  });
+
+  it('should note when reusing previously configured message', async () => {
+    callGraphAPI
+      .mockResolvedValueOnce({}) // PATCH
+      .mockResolvedValueOnce({
+        status: 'alwaysEnabled',
+        internalReplyMessage: 'I am out of office until Monday',
+      }); // GET updated — has existing message
+
+    const result = await handleSetAutomaticReplies({ enabled: true });
+
+    expect(result.content[0].text).toContain('Note');
+    expect(result.content[0].text).toContain('previously configured');
+    expect(result.content[0].text).toContain('I am out of office');
+  });
+
+  it('should not warn when messages are provided', async () => {
+    callGraphAPI
+      .mockResolvedValueOnce({}) // PATCH
+      .mockResolvedValueOnce({
+        status: 'alwaysEnabled',
+        internalReplyMessage: 'New message',
+      }); // GET updated
+
+    const result = await handleSetAutomaticReplies({
+      enabled: true,
+      internalReplyMessage: 'New message',
+    });
+
+    expect(result.content[0].text).not.toContain('Warning');
+    expect(result.content[0].text).not.toContain('Note');
   });
 
   it('should reject invalid externalAudience', async () => {

--- a/utils/field-presets.js
+++ b/utils/field-presets.js
@@ -16,6 +16,22 @@ const FIELD_PRESETS = {
   list: ['id', 'subject', 'from', 'receivedDateTime', 'isRead'],
 
   /**
+   * Minimal fields for reading a single email
+   * Use case: Quick read at minimal verbosity (includes bodyPreview + toRecipients)
+   */
+  'read-minimal': [
+    'id',
+    'subject',
+    'from',
+    'toRecipients',
+    'receivedDateTime',
+    'bodyPreview',
+    'hasAttachments',
+    'importance',
+    'isRead',
+  ],
+
+  /**
    * Standard fields for reading email content
    * Use case: Viewing email details with body
    */

--- a/utils/response-formatter.js
+++ b/utils/response-formatter.js
@@ -223,9 +223,11 @@ function formatEmailContent(
 
   let output = `# ${email.subject || '(no subject)'}
 
-**From:** ${from}
-**To:** ${to}
-**Date:** ${date}`;
+**From:** ${from}`;
+
+  if (to) output += `\n**To:** ${to}`;
+
+  output += `\n**Date:** ${date}`;
 
   if (cc) output += `\n**CC:** ${cc}`;
   if (bcc) output += `\n**BCC:** ${bcc}`;
@@ -245,7 +247,10 @@ function formatEmailContent(
 
   // Body content
   let body = '';
-  if (email.body) {
+  if (verbosity === VERBOSITY.MINIMAL) {
+    // At minimal verbosity, show bodyPreview only
+    body = email.bodyPreview || '_(Body omitted at minimal verbosity)_';
+  } else if (email.body) {
     body =
       email.body.contentType === 'html'
         ? stripHtml(email.body.content)

--- a/yarn.lock
+++ b/yarn.lock
@@ -527,9 +527,9 @@
   integrity sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==
 
 "@hono/node-server@^1.19.9":
-  version "1.19.9"
-  resolved "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz"
-  integrity sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==
+  version "1.19.11"
+  resolved "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz"
+  integrity sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==
 
 "@humanfs/core@^0.19.1":
   version "0.19.1"
@@ -2859,9 +2859,9 @@ hasown@^2.0.2:
     function-bind "^1.1.2"
 
 hono@^4, hono@^4.11.4:
-  version "4.12.2"
-  resolved "https://registry.npmjs.org/hono/-/hono-4.12.2.tgz"
-  integrity sha512-gJnaDHXKDayjt8ue0n8Gs0A007yKXj4Xzb8+cNjZeYsSzzwKc0Lr+OZgYwVfB0pHfUs17EPoLvrOsEaJ9mj+Tg==
+  version "4.12.5"
+  resolved "https://registry.npmjs.org/hono/-/hono-4.12.5.tgz"
+  integrity sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==
 
 htm@^3.1.1:
   version "3.1.1"


### PR DESCRIPTION
## Summary

Resolves all 13 open issues (#46–#58) for the v3.2.0 release:

**Bug fixes (7):**
- **#46** — Throw error for nonexistent folder instead of silent inbox fallback
- **#47** — Validate `count >= 1` in search-emails; use nullish coalescing
- **#48** — read-email minimal verbosity now shows bodyPreview and To field
- **#49** — Detect HTML body content type with broader tag matching (not just `<html`)
- **#50** — Conversation export returns friendly error on personal accounts
- **#51** — Calendar event times display in configured timezone (not UTC)
- **#52** — Rule sequence shows actual server value, not positional index

**Enhancements (6):**
- **#53** — `auth about` shows diagnostic info (tools, scopes, config)
- **#54** — `folders action=delete` with protected folder guard
- **#55** — `manage-rules action=delete` by name or ID
- **#56** — Contact minimal verbosity shows only name and email
- **#57** — `mailbox-settings` section-specific get returns formatted output
- **#58** — `set-auto-replies` warns when enabling without message

**Also:**
- CHANGELOG, README, tools reference, and 3 how-to guides updated
- Security vulnerabilities in hono transitive dependencies fixed
- 388 tests passing, 0 lint errors, 0 security vulnerabilities

## Files changed

- 49 files changed, 887 insertions, 195 deletions
- 1 new file: `folder/delete.js`

## Test plan

- [x] `npm test` — 388 tests pass (14 suites)
- [x] `npx eslint .` — 0 errors
- [x] `npx prettier --check .` — all tracked files formatted
- [x] `npm audit` — 0 vulnerabilities
- [ ] CI pipeline passes (lint, format, test on Node 18/20/22, audit)

Closes #46, closes #47, closes #48, closes #49, closes #50, closes #51, closes #52, closes #53, closes #54, closes #55, closes #56, closes #57, closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)