### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ Outlook Assistant connects AI assistants to your Microsoft Outlook account throu
 | Manually check each email for phishing red flags | Forensic header analysis — DKIM, SPF, DMARC, spam scores, and delivery chain in one call |
 | Poll your inbox to check for new mail | Delta sync returns only changes since your last check, with tokens for continuous polling |
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/littlebearapps-outlook-assistant).
+
 ## Features
 
 | Module | Tools | What You Can Do |


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/littlebearapps-outlook-assistant).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added hosted deployment information to the README, directing users to a hosted offering on Frontier AI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->