### PR TITLE
fix: persist device code state & fix token refresh for public clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.7.2] - 2026-04
+
+### Fixed
+
+- **Device code auth state lost on MCP server restart** — the pending device code was stored only in module-level memory, which is lost when the MCP server process restarts between the `authenticate` and `device-code-complete` tool calls. Now persisted to `~/.outlook-assistant-pending-auth.json` (mode 0o600) so the completion step works even after server restarts. Critical for Untether (Telegram bridge) and any environment where MCP servers restart between tool calls. (#142)
+- **Token refresh fails for device-code auth** — `refreshAccessToken()` unconditionally included `client_secret` in refresh requests, but device code flow is a public client flow where Microsoft rejects `client_secret` ("Public clients can't send a client secret"). Now stores `auth_method: "device-code"` in the token file and conditionally excludes `client_secret` from refresh requests for device-code-obtained tokens. Browser-flow tokens continue to include `client_secret` as before. (#143)
+
+### Added
+
+- **`auth_method` field in token file** — tokens now include `auth_method: "device-code"` or `auth_method: "browser"` to track how they were obtained, enabling correct refresh behaviour for each flow.
+- **New test files** `test/auth/auth-tools.test.js` and `test/auth/token-refresh.test.js` — 10 tests covering device code state persistence, disk fallback, expiry cleanup, auth_method propagation, and conditional `client_secret` handling.
+
 ## [3.7.1] - 2026-04
 
 ### Fixed

--- a/auth/token-storage.js
+++ b/auth/token-storage.js
@@ -49,11 +49,13 @@ class TokenStorage {
       }
     }
 
-    if (!this.config.clientId || !this.config.clientSecret) {
+    if (!this.config.clientId) {
       console.warn(
-        'TokenStorage: OUTLOOK_CLIENT_ID or OUTLOOK_CLIENT_SECRET is not configured. Token operations might fail.'
+        'TokenStorage: OUTLOOK_CLIENT_ID is not configured. Token operations will fail.'
       );
     }
+    // client_secret is only required for browser flow (confidential client).
+    // Device code flow (public client) does not use client_secret.
   }
 
   async _loadTokensFromFile() {
@@ -158,14 +160,24 @@ class TokenStorage {
       return this._refreshPromise.then((tokens) => tokens.access_token);
     }
 
-    console.log('Attempting to refresh access token...');
-    const postData = querystring.stringify({
+    // Device code flow is a public client flow — Microsoft rejects client_secret
+    // in refresh requests for tokens obtained via device code.
+    // Browser flow (confidential client) requires client_secret.
+    const isDeviceCode = this.tokens.auth_method === 'device-code';
+    console.log(
+      `Attempting to refresh access token (auth_method: ${this.tokens.auth_method || 'browser'})...`
+    );
+
+    const refreshParams = {
       client_id: this.config.clientId,
-      client_secret: this.config.clientSecret,
       grant_type: 'refresh_token',
       refresh_token: this.tokens.refresh_token,
       scope: this.config.scopes.join(' '),
-    });
+    };
+    if (!isDeviceCode) {
+      refreshParams.client_secret = this.config.clientSecret;
+    }
+    const postData = querystring.stringify(refreshParams);
 
     const requestOptions = {
       method: 'POST',

--- a/auth/tools.js
+++ b/auth/tools.js
@@ -2,8 +2,16 @@
  * Authentication-related tools for the Outlook Assistant server
  */
 const config = require('../config');
+const fs = require('fs');
+const path = require('path');
 const tokenManager = require('./token-manager');
 const { initiateDeviceCodeFlow, pollForToken } = require('./device-code');
+
+// Path for persisting device code state across MCP server restarts
+const DEVICE_CODE_STATE_PATH = path.join(
+  process.env.HOME || process.env.USERPROFILE,
+  '.outlook-assistant-pending-auth.json'
+);
 
 // Dynamic tool count — set by index.js after TOOLS array is built
 let _toolCount = 0;
@@ -89,12 +97,57 @@ async function handleAuthenticate(args) {
   };
 }
 
-// Module-level state for pending device code flow
+// In-memory state for pending device code flow (also persisted to disk)
 let pendingDeviceCode = null;
+
+/**
+ * Save device code state to disk so it survives MCP server restarts.
+ * Uses mode 0o600 (owner-only) — same as token file.
+ * @param {object|null} state - Device code state or null to delete
+ */
+function saveDeviceCodeState(state) {
+  try {
+    if (state) {
+      fs.writeFileSync(DEVICE_CODE_STATE_PATH, JSON.stringify(state), {
+        mode: 0o600,
+      });
+    } else if (fs.existsSync(DEVICE_CODE_STATE_PATH)) {
+      fs.unlinkSync(DEVICE_CODE_STATE_PATH);
+    }
+  } catch (error) {
+    console.error(
+      `[AUTH] Failed to ${state ? 'save' : 'clean up'} device code state: ${error.message}`
+    );
+  }
+}
+
+/**
+ * Load device code state from disk (fallback when in-memory state is lost).
+ * Returns null if no state exists or if the state has expired.
+ * @returns {object|null}
+ */
+function loadDeviceCodeState() {
+  try {
+    if (!fs.existsSync(DEVICE_CODE_STATE_PATH)) {
+      return null;
+    }
+    const state = JSON.parse(fs.readFileSync(DEVICE_CODE_STATE_PATH, 'utf8'));
+    if (Date.now() > state.expiresAt) {
+      console.error('[AUTH] Persisted device code has expired, cleaning up');
+      saveDeviceCodeState(null);
+      return null;
+    }
+    return state;
+  } catch (error) {
+    console.error(`[AUTH] Failed to load device code state: ${error.message}`);
+    return null;
+  }
+}
 
 /**
  * Device code flow step 1 — request a code for the user to enter.
  * Returns the code + URL immediately. Call device-code-complete to finish.
+ * State is persisted to disk so it survives MCP server restarts.
  * @returns {object} - MCP response
  */
 async function handleDeviceCodeAuth() {
@@ -116,13 +169,14 @@ async function handleDeviceCodeAuth() {
     config.AUTH_CONFIG.scopes
   );
 
-  // Store for the completion step
+  // Store in memory and persist to disk
   pendingDeviceCode = {
     deviceCode: response.deviceCode,
     interval: response.interval,
     expiresIn: response.expiresIn,
     expiresAt: Date.now() + response.expiresIn * 1000,
   };
+  saveDeviceCodeState(pendingDeviceCode);
 
   console.error(
     `[AUTH] Device code: ${response.userCode}, expires in ${response.expiresIn}s`
@@ -146,9 +200,15 @@ async function handleDeviceCodeAuth() {
 
 /**
  * Device code flow step 2 — poll until the user completes authentication.
+ * Checks in-memory state first, falls back to disk-persisted state.
  * @returns {object} - MCP response
  */
 async function handleDeviceCodeComplete() {
+  // Try in-memory first, fall back to disk (survives server restarts)
+  if (!pendingDeviceCode) {
+    pendingDeviceCode = loadDeviceCodeState();
+  }
+
   if (!pendingDeviceCode) {
     return {
       content: [
@@ -162,6 +222,7 @@ async function handleDeviceCodeComplete() {
 
   if (Date.now() > pendingDeviceCode.expiresAt) {
     pendingDeviceCode = null;
+    saveDeviceCodeState(null);
     return {
       content: [
         {
@@ -184,8 +245,9 @@ async function handleDeviceCodeComplete() {
     );
 
     pendingDeviceCode = null;
+    saveDeviceCodeState(null);
 
-    // Save tokens using TokenStorage
+    // Save tokens using TokenStorage — mark as device-code auth
     const TokenStorage = require('./token-storage');
     const tokenStorage = new TokenStorage({
       clientId: config.AUTH_CONFIG.clientId,
@@ -202,6 +264,7 @@ async function handleDeviceCodeComplete() {
       expires_at: Date.now() + tokenResponse.expires_in * 1000,
       scope: tokenResponse.scope,
       token_type: tokenResponse.token_type,
+      auth_method: 'device-code',
     };
     await tokenStorage._saveTokensToFile();
 
@@ -217,6 +280,7 @@ async function handleDeviceCodeComplete() {
     };
   } catch (error) {
     pendingDeviceCode = null;
+    saveDeviceCodeState(null);
     return {
       content: [
         {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@littlebearapps/outlook-assistant",
-  "version": "3.7.1",
+  "version": "3.7.2",
   "mcpName": "io.github.littlebearapps/outlook-assistant",
   "description": "Outlook Assistant — MCP server with 22 tools for email, calendar, contacts, and settings via Microsoft Graph API",
   "main": "index.js",

--- a/test/auth/auth-tools.test.js
+++ b/test/auth/auth-tools.test.js
@@ -1,0 +1,211 @@
+const fs = require('fs');
+const path = require('path');
+
+// Mock dependencies before requiring the module under test
+jest.mock('../../auth/device-code');
+jest.mock('../../auth/token-manager');
+jest.mock('../../auth/token-storage');
+
+const DEVICE_CODE_STATE_PATH = path.join(
+  process.env.HOME || process.env.USERPROFILE,
+  '.outlook-assistant-pending-auth.json'
+);
+
+// Mock config
+jest.mock('../../config', () => ({
+  AUTH_CONFIG: {
+    clientId: 'test-client-id',
+    clientSecret: 'test-client-secret',
+    scopes: ['offline_access', 'User.Read', 'Mail.Read'],
+    tokenStorePath: '/tmp/test-tokens.json',
+    tokenEndpoint: 'https://login.microsoftonline.com/common/oauth2/v2.0/token',
+    authServerUrl: 'http://localhost:3333',
+    defaultAuthMethod: 'device-code',
+  },
+  USE_TEST_MODE: false,
+  SERVER_VERSION: '3.7.2',
+  DEFAULT_TIMEZONE: 'Australia/Melbourne',
+}));
+
+const {
+  handleDeviceCodeAuth,
+  handleDeviceCodeComplete,
+} = require('../../auth/tools');
+const {
+  initiateDeviceCodeFlow,
+  pollForToken,
+} = require('../../auth/device-code');
+const TokenStorage = require('../../auth/token-storage');
+
+describe('device code state persistence', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    // Clean up any persisted state file
+    try {
+      fs.unlinkSync(DEVICE_CODE_STATE_PATH);
+    } catch {
+      // Ignore if file doesn't exist
+    }
+  });
+
+  afterEach(() => {
+    console.error.mockRestore();
+    try {
+      fs.unlinkSync(DEVICE_CODE_STATE_PATH);
+    } catch {
+      // Ignore
+    }
+  });
+
+  test('handleDeviceCodeComplete returns error when no state exists', async () => {
+    // No in-memory state, no file on disk — test this FIRST before any initiation
+    const result = await handleDeviceCodeComplete();
+    expect(result.content[0].text).toContain('No pending device code flow');
+  });
+
+  test('handleDeviceCodeComplete loads state from disk when in-memory is lost', async () => {
+    // Simulate: device code was initiated in a previous server process
+    // Write state directly to disk (as if previous process saved it)
+    const state = {
+      deviceCode: 'device_code_from_disk',
+      interval: 5,
+      expiresIn: 900,
+      expiresAt: Date.now() + 900 * 1000,
+    };
+    fs.writeFileSync(DEVICE_CODE_STATE_PATH, JSON.stringify(state), {
+      mode: 0o600,
+    });
+
+    // Mock successful token response
+    pollForToken.mockResolvedValue({
+      access_token: 'test_access_token',
+      refresh_token: 'test_refresh_token',
+      expires_in: 3600,
+      scope: 'User.Read Mail.Read',
+      token_type: 'Bearer',
+    });
+
+    // Mock TokenStorage
+    const mockInstance = {
+      tokens: null,
+      _saveTokensToFile: jest.fn().mockResolvedValue(undefined),
+    };
+    TokenStorage.mockImplementation(() => mockInstance);
+
+    const result = await handleDeviceCodeComplete();
+
+    // Should succeed using disk-persisted state
+    expect(result.content[0].text).toContain('Authentication successful');
+    expect(pollForToken).toHaveBeenCalledWith(
+      'test-client-id',
+      'device_code_from_disk',
+      5,
+      expect.any(Number)
+    );
+
+    // State file should be cleaned up
+    expect(fs.existsSync(DEVICE_CODE_STATE_PATH)).toBe(false);
+  });
+
+  test('handleDeviceCodeAuth persists state to disk', async () => {
+    initiateDeviceCodeFlow.mockResolvedValue({
+      userCode: 'TESTCODE',
+      verificationUri: 'https://microsoft.com/devicelogin',
+      deviceCode: 'device_code_abc123',
+      expiresIn: 900,
+      interval: 5,
+    });
+
+    const result = await handleDeviceCodeAuth();
+
+    // Should return the code to the user
+    expect(result.content[0].text).toContain('TESTCODE');
+    expect(result.content[0].text).toContain('microsoft.com/devicelogin');
+
+    // Should have persisted state to disk
+    expect(fs.existsSync(DEVICE_CODE_STATE_PATH)).toBe(true);
+    const state = JSON.parse(fs.readFileSync(DEVICE_CODE_STATE_PATH, 'utf8'));
+    expect(state.deviceCode).toBe('device_code_abc123');
+    expect(state.interval).toBe(5);
+    expect(state.expiresAt).toBeGreaterThan(Date.now());
+
+    // Consume the in-memory state so it doesn't leak to subsequent tests
+    pollForToken.mockRejectedValue(new Error('test cleanup'));
+    TokenStorage.mockImplementation(() => ({
+      tokens: null,
+      _saveTokensToFile: jest.fn(),
+    }));
+    await handleDeviceCodeComplete();
+  });
+
+  test('handleDeviceCodeComplete cleans up expired state from disk', async () => {
+    // Write expired state
+    const state = {
+      deviceCode: 'expired_code',
+      interval: 5,
+      expiresIn: 900,
+      expiresAt: Date.now() - 60000, // Expired 1 minute ago
+    };
+    fs.writeFileSync(DEVICE_CODE_STATE_PATH, JSON.stringify(state));
+
+    const result = await handleDeviceCodeComplete();
+    expect(result.content[0].text).toContain('No pending device code flow');
+    // Expired file should be cleaned up
+    expect(fs.existsSync(DEVICE_CODE_STATE_PATH)).toBe(false);
+  });
+
+  test('handleDeviceCodeComplete saves auth_method in tokens', async () => {
+    // Write valid state to disk
+    const state = {
+      deviceCode: 'device_code_test',
+      interval: 5,
+      expiresIn: 900,
+      expiresAt: Date.now() + 900 * 1000,
+    };
+    fs.writeFileSync(DEVICE_CODE_STATE_PATH, JSON.stringify(state));
+
+    pollForToken.mockResolvedValue({
+      access_token: 'test_access_token',
+      refresh_token: 'test_refresh_token',
+      expires_in: 3600,
+      scope: 'User.Read Mail.Read',
+      token_type: 'Bearer',
+    });
+
+    let savedTokens = null;
+    TokenStorage.mockImplementation(() => {
+      const instance = {
+        tokens: null,
+        _saveTokensToFile: jest.fn().mockImplementation(function () {
+          savedTokens = this.tokens;
+          return Promise.resolve();
+        }),
+      };
+      return instance;
+    });
+
+    await handleDeviceCodeComplete();
+
+    // Verify auth_method was set
+    expect(savedTokens).not.toBeNull();
+    expect(savedTokens.auth_method).toBe('device-code');
+  });
+
+  test('state file has restrictive permissions (0o600)', async () => {
+    initiateDeviceCodeFlow.mockResolvedValue({
+      userCode: 'TESTCODE',
+      verificationUri: 'https://microsoft.com/devicelogin',
+      deviceCode: 'device_code_perms_test',
+      expiresIn: 900,
+      interval: 5,
+    });
+
+    await handleDeviceCodeAuth();
+
+    const stats = fs.statSync(DEVICE_CODE_STATE_PATH);
+    // Check owner-only permissions (0o600 = rw-------)
+    const mode = stats.mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+});

--- a/test/auth/token-refresh.test.js
+++ b/test/auth/token-refresh.test.js
@@ -1,0 +1,175 @@
+const https = require('https');
+const TokenStorage = require('../../auth/token-storage');
+
+jest.mock('https');
+
+/**
+ * Helper to mock an HTTPS POST response and capture the request body
+ */
+function mockHttpsResponse(statusCode, body) {
+  let capturedPostData = '';
+  const mockRes = {
+    statusCode,
+    on: jest.fn((event, cb) => {
+      if (event === 'data') cb(JSON.stringify(body));
+      if (event === 'end') cb();
+      return mockRes;
+    }),
+  };
+  const mockReq = {
+    on: jest.fn(),
+    write: jest.fn((data) => {
+      capturedPostData = data;
+    }),
+    end: jest.fn(),
+  };
+  https.request.mockImplementationOnce((_url, _opts, cb) => {
+    cb(mockRes);
+    return mockReq;
+  });
+  return { getCapturedPostData: () => capturedPostData };
+}
+
+describe('TokenStorage.refreshAccessToken — client_secret handling', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    console.log.mockRestore();
+    console.error.mockRestore();
+    console.warn.mockRestore();
+  });
+
+  test('should NOT include client_secret for device-code tokens', async () => {
+    const storage = new TokenStorage({
+      clientId: 'test-client-id',
+      clientSecret: 'test-secret',
+      tokenEndpoint:
+        'https://login.microsoftonline.com/common/oauth2/v2.0/token',
+      scopes: ['offline_access', 'User.Read'],
+    });
+
+    // Load device-code tokens
+    storage.tokens = {
+      access_token: 'expired_access',
+      refresh_token: 'valid_refresh',
+      expires_at: Date.now() - 60000, // Expired
+      auth_method: 'device-code',
+    };
+
+    // Mock _saveTokensToFile
+    storage._saveTokensToFile = jest.fn().mockResolvedValue(undefined);
+
+    const { getCapturedPostData } = mockHttpsResponse(200, {
+      access_token: 'new_access_token',
+      refresh_token: 'new_refresh_token',
+      expires_in: 3600,
+    });
+
+    await storage.refreshAccessToken();
+
+    const postData = getCapturedPostData();
+    // Should NOT contain client_secret
+    expect(postData).not.toContain('client_secret');
+    // Should contain other required fields
+    expect(postData).toContain('client_id=test-client-id');
+    expect(postData).toContain('grant_type=refresh_token');
+    expect(postData).toContain('refresh_token=valid_refresh');
+  });
+
+  test('should include client_secret for browser-flow tokens', async () => {
+    const storage = new TokenStorage({
+      clientId: 'test-client-id',
+      clientSecret: 'test-secret',
+      tokenEndpoint:
+        'https://login.microsoftonline.com/common/oauth2/v2.0/token',
+      scopes: ['offline_access', 'User.Read'],
+    });
+
+    // Load browser-flow tokens (no auth_method field)
+    storage.tokens = {
+      access_token: 'expired_access',
+      refresh_token: 'valid_refresh',
+      expires_at: Date.now() - 60000,
+      // No auth_method — defaults to browser/confidential client
+    };
+
+    storage._saveTokensToFile = jest.fn().mockResolvedValue(undefined);
+
+    const { getCapturedPostData } = mockHttpsResponse(200, {
+      access_token: 'new_access_token',
+      refresh_token: 'new_refresh_token',
+      expires_in: 3600,
+    });
+
+    await storage.refreshAccessToken();
+
+    const postData = getCapturedPostData();
+    // SHOULD contain client_secret for browser flow
+    expect(postData).toContain('client_secret=test-secret');
+    expect(postData).toContain('client_id=test-client-id');
+  });
+
+  test('should include client_secret when auth_method is explicitly browser', async () => {
+    const storage = new TokenStorage({
+      clientId: 'test-client-id',
+      clientSecret: 'test-secret',
+      tokenEndpoint:
+        'https://login.microsoftonline.com/common/oauth2/v2.0/token',
+      scopes: ['offline_access', 'User.Read'],
+    });
+
+    storage.tokens = {
+      access_token: 'expired_access',
+      refresh_token: 'valid_refresh',
+      expires_at: Date.now() - 60000,
+      auth_method: 'browser',
+    };
+
+    storage._saveTokensToFile = jest.fn().mockResolvedValue(undefined);
+
+    const { getCapturedPostData } = mockHttpsResponse(200, {
+      access_token: 'new_access_token',
+      expires_in: 3600,
+    });
+
+    await storage.refreshAccessToken();
+
+    const postData = getCapturedPostData();
+    expect(postData).toContain('client_secret=test-secret');
+  });
+
+  test('should preserve auth_method after refresh', async () => {
+    const storage = new TokenStorage({
+      clientId: 'test-client-id',
+      clientSecret: 'test-secret',
+      tokenEndpoint:
+        'https://login.microsoftonline.com/common/oauth2/v2.0/token',
+      scopes: ['offline_access', 'User.Read'],
+    });
+
+    storage.tokens = {
+      access_token: 'expired_access',
+      refresh_token: 'valid_refresh',
+      expires_at: Date.now() - 60000,
+      auth_method: 'device-code',
+    };
+
+    storage._saveTokensToFile = jest.fn().mockResolvedValue(undefined);
+
+    mockHttpsResponse(200, {
+      access_token: 'new_access_token',
+      refresh_token: 'new_refresh_token',
+      expires_in: 3600,
+    });
+
+    await storage.refreshAccessToken();
+
+    // auth_method should still be device-code after refresh
+    expect(storage.tokens.auth_method).toBe('device-code');
+  });
+});

--- a/test/auth/token-storage.test.js
+++ b/test/auth/token-storage.test.js
@@ -55,11 +55,11 @@ describe('TokenStorage', () => {
       expect(tokenStorage.config.refreshTokenBuffer).toBe(5 * 60 * 1000);
     });
 
-    it('should warn if client ID or secret is missing', () => {
+    it('should warn if client ID is missing', () => {
       const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
       new TokenStorage({ ...baseConfig, clientId: null });
       expect(consoleWarnSpy).toHaveBeenCalledWith(
-        'TokenStorage: OUTLOOK_CLIENT_ID or OUTLOOK_CLIENT_SECRET is not configured. Token operations might fail.'
+        'TokenStorage: OUTLOOK_CLIENT_ID is not configured. Token operations will fail.'
       );
       consoleWarnSpy.mockRestore();
     });


### PR DESCRIPTION
## Summary

- **Fixes device code auth state lost on MCP server restart** (#142) — pending device code now persisted to `~/.outlook-assistant-pending-auth.json` (mode 0o600) so `device-code-complete` works even after server restarts
- **Fixes token refresh failing for device-code auth** (#143) — `client_secret` no longer sent in refresh requests for device-code tokens (public client flow), which Microsoft rejects with "Public clients can't send a client secret"

### Changes

**`auth/tools.js`**:
- `saveDeviceCodeState()` / `loadDeviceCodeState()` — disk persistence helpers
- `handleDeviceCodeAuth()` — now persists state to disk alongside in-memory
- `handleDeviceCodeComplete()` — falls back to disk state when in-memory is lost
- Tokens now include `auth_method: "device-code"` for correct refresh behaviour

**`auth/token-storage.js`**:
- `refreshAccessToken()` — conditionally excludes `client_secret` when `auth_method === "device-code"`
- Constructor warning updated (client_secret not required for device-code flow)

**New test files**:
- `test/auth/auth-tools.test.js` — 6 tests for state persistence, disk fallback, expiry cleanup, auth_method, file permissions
- `test/auth/token-refresh.test.js` — 4 tests for conditional client_secret handling

**`CHANGELOG.md`**: v3.7.2 entry
**`package.json`**: 3.7.1 → 3.7.2

## Test plan

- [x] 608/608 tests pass, 0 regressions
- [x] Device code state persists to disk and loads correctly after server restart
- [x] Expired state files are cleaned up automatically
- [x] `auth_method: "device-code"` stored in token file
- [x] Refresh request excludes `client_secret` for device-code tokens
- [x] Refresh request includes `client_secret` for browser-flow tokens (backwards compatible)
- [x] State file created with 0o600 permissions
- [ ] Live test: authenticate via device code across Untether session boundary

Closes #142, closes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Device-code authentication state now persists across MCP server restarts, enabling the authentication flow to complete successfully
  * Token refresh requests for device-code authenticated sessions no longer send unnecessary client credentials

<!-- end of auto-generated comment: release notes by coderabbit.ai -->