### PR TITLE
docs: update auth documentation for v3.7.2 fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,8 +103,9 @@ utils/
 |------|---------|
 | `index.js` | MCP protocol handler, combines all tools |
 | `config.js` | API endpoint, auth settings, defaults |
-| `auth/token-storage.js` | Token storage with auto-refresh at `~/.outlook-assistant-tokens.json` |
+| `auth/token-storage.js` | Token storage with auto-refresh at `~/.outlook-assistant-tokens.json` (includes `auth_method` field) |
 | `auth/device-code.js` | Device code flow for headless/remote authentication |
+| `auth/tools.js` | Auth tool handlers; persists device code state to `~/.outlook-assistant-pending-auth.json` |
 | `utils/graph-api.js` | All Graph API calls go through here (includes $batch) |
 | `email/mail-tips.js` | Pre-send recipient validation |
 | `utils/safety.js` | Rate limiter, allowlist, dry-run preview |
@@ -174,6 +175,8 @@ OUTLOOK_AUTH_METHOD=device-code            # Optional: default auth method (devi
 | Device code sign-in shows "wrongplace" | Normal — sign-in completed. Close the browser, call `device-code-complete` |
 | Device code sign-in redirects to localhost | Use incognito/private browser for `microsoft.com/devicelogin` |
 | `device-code-complete` hangs | Tool is polling (not a permission prompt). Wait 10-15s. If still hanging, sign-in didn't complete — get new code, use incognito browser |
+| `device-code-complete` "no pending flow" | Fixed in v3.7.2 — device code state now persists to disk, surviving MCP server restarts. Update to v3.7.2+ |
+| Token refresh fails after ~60 min (device code) | Fixed in v3.7.2 — earlier versions sent `client_secret` for public client refresh. Update to v3.7.2+ |
 | `search-emails` returns 503 error | Fixed in v3.5.2 — `query` now falls back to `contains(subject)` on personal accounts. For body search, use `kqlQuery` (#98) |
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -356,6 +356,8 @@ No auth server needed. Works everywhere, including remote/headless environments.
 5. Tokens are saved to `~/.outlook-assistant-tokens.json` and **refresh automatically**
 
 > **Prerequisite**: Enable "Allow public client flows" in Azure Portal > your app > Authentication > Advanced settings.
+>
+> **Server restarts** (v3.7.2+): Device code state is persisted to `~/.outlook-assistant-pending-auth.json`, so `device-code-complete` works even if the MCP server restarts between steps 1 and 4 (e.g., Untether/Telegram bridge, Claude Desktop session changes).
 
 ### Browser Redirect Flow (Alternative)
 
@@ -430,6 +432,10 @@ If using browser flow: start the auth server first with `npm run auth-server`. I
 ### Device code "invalid_client"
 
 Enable "Allow public client flows" in Azure Portal > App registrations > Authentication > Advanced settings.
+
+### Token refresh fails after ~60 minutes (device code auth)
+
+Fixed in v3.7.2. Earlier versions sent `client_secret` in token refresh requests for device-code auth, which Microsoft rejects for public client flows. Update to v3.7.2+ or re-authenticate.
 
 ### Empty API responses
 

--- a/docs/guides/azure-setup.md
+++ b/docs/guides/azure-setup.md
@@ -183,7 +183,7 @@ The device code flow lets you authenticate without running the auth server — i
 7. Set **Allow public client flows** to **Yes**
 8. Click **Save**
 
-> **Why?** Device code flow is a "public client" flow that doesn't require the client secret during authentication. This is the default auth method in Outlook Assistant v3.5.1+. The native client redirect URI tells Microsoft to handle device code sign-in correctly.
+> **Why?** Device code flow is a "public client" flow that doesn't require the client secret during authentication. This is the default auth method in Outlook Assistant v3.5.1+. The native client redirect URI tells Microsoft to handle device code sign-in correctly. In v3.7.2+, device code state is persisted to disk (`~/.outlook-assistant-pending-auth.json`) so authentication survives MCP server restarts, and token refresh correctly omits `client_secret` for public client tokens.
 >
 > If you skip this step, you can still authenticate using the browser redirect flow (`method=browser`), but you'll need to run the auth server on port 3333.
 

--- a/docs/how-to/getting-started/connect-outlook-to-claude.md
+++ b/docs/how-to/getting-started/connect-outlook-to-claude.md
@@ -120,6 +120,8 @@ Your AI assistant will call the `auth` tool with `action: authenticate`. You'll 
 
 4. Tell your AI assistant you've completed sign-in. It will call `auth` with `action: device-code-complete` to finish authentication. Tokens are saved to `~/.outlook-assistant-tokens.json`.
 
+> **Server restarts** (v3.7.2+): Device code state is persisted to disk, so `device-code-complete` works even if the MCP server restarts between steps 1 and 4.
+
 ### Browser Redirect Flow (Alternative)
 
 If you prefer the traditional OAuth browser redirect (e.g. for localhost development):

--- a/docs/how-to/getting-started/verify-your-connection.md
+++ b/docs/how-to/getting-started/verify-your-connection.md
@@ -87,7 +87,7 @@ This returns the server version, available tools, and configuration details.
 | Token file exists but auth reports failure | Corrupted token file | Delete `~/.outlook-assistant-tokens.json` and re-authenticate |
 | Auth server says "missing client ID" | Auth server does not have env vars | Create a `.env` file or export `OUTLOOK_CLIENT_ID`/`OUTLOOK_CLIENT_SECRET` in your shell — see [Connect guide](connect-outlook-to-claude.md#authenticate-for-the-first-time) |
 | Device code "invalid_client" | Public client flows not enabled | Enable "Allow public client flows" in Azure Portal > App registrations > Authentication > Advanced settings |
-| "No pending device code flow" | Called `device-code-complete` before `authenticate` | Call `auth` with `action: authenticate` first to get the code, then `action: device-code-complete` |
+| "No pending device code flow" | Called `device-code-complete` before `authenticate`, or server restarted (pre-v3.7.2) | Call `auth` with `action: authenticate` first. In v3.7.2+, device code state persists across server restarts. |
 | "wrongplace" page after device code sign-in | Normal — means sign-in completed but Microsoft doesn't know where to redirect | Close the browser tab. The device code flow completed successfully. Call `device-code-complete` to finish. |
 | Device code sign-in redirects to localhost | Cached browser session interfering with device code flow | Use a **private/incognito browser window** for `microsoft.com/devicelogin` |
 | `device-code-complete` hangs silently | The tool is polling Microsoft (not a permission prompt) — sign-in may not have completed | Wait 10-15 seconds. If still hanging, press Escape, get a new code, sign in with incognito browser, and try again |

--- a/docs/quickrefs/tools-reference.md
+++ b/docs/quickrefs/tools-reference.md
@@ -11,7 +11,7 @@ Quick reference for all 22 MCP tools across 9 modules. Each tool includes MCP sa
 
 | Tool | Actions | Safety | Key Parameters |
 |------|---------|--------|----------------|
-| `auth` | `status` (default), `authenticate`, `device-code-complete`, `about` | moderate write | `method` (`device-code` default, `browser`), `force` |
+| `auth` | `status` (default), `authenticate`, `device-code-complete`, `about` | moderate write | `method` (`device-code` default, `browser`), `force`. Device code state persists across server restarts (v3.7.2+). |
 
 ## Email (8 tools)
 


### PR DESCRIPTION
## Summary

- Adds succinct notes about v3.7.2 auth improvements to 6 documentation files
- Device code state persistence across MCP server restarts
- Token refresh fix for public client flows (no more client_secret for device-code tokens)

### Files Updated

| File | Change |
|------|--------|
| `README.md` | Server restart note in device code section + new troubleshooting entry |
| `CLAUDE.md` | `auth/tools.js` in key files table + 2 new common issues entries |
| `docs/how-to/getting-started/connect-outlook-to-claude.md` | Server restart note after step 4 |
| `docs/how-to/getting-started/verify-your-connection.md` | Updated "no pending flow" troubleshooting |
| `docs/guides/azure-setup.md` | v3.7.2 state persistence note |
| `docs/quickrefs/tools-reference.md` | State persistence note for auth tool |

## Test plan

- [x] 608/608 tests pass (docs-only changes)
- [x] No contradictions with existing text

🤖 Generated with [Claude Code](https://claude.com/claude-code)