### PR TITLE
docs: extract troubleshooting + finish CLAUDE.md slim

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,22 +27,8 @@ npx kill-port 3333       # Kill auth server if port blocked
 - Enable "Allow public client flows" in Authentication > Advanced settings
 - Use a **private/incognito browser** for `microsoft.com/devicelogin` (avoids cached session interference)
 
-**Browser flow (alternative, for localhost use):**
-The auth server needs `OUTLOOK_CLIENT_ID` and `OUTLOOK_CLIENT_SECRET` env vars. These are stored in Bitwarden Secrets Manager as `outlook-client-id` and `outlook-client-secret`. Claude Code shells don't inherit direnv, so start the auth server manually:
-
-```bash
-source ~/bin/kc.sh && \
-  export OUTLOOK_CLIENT_ID=$(kc_get outlook-client-id) && \
-  export OUTLOOK_CLIENT_SECRET=$(kc_get outlook-client-secret) && \
-  node outlook-auth-server.js
-```
-
-The MCP server itself gets credentials via `.mcp.json` inline `kc_get` calls — no manual export needed for normal operation.
-
-For remote testing with browser flow (e.g. MacBook → VPS), SSH tunnel port 3333:
-```bash
-ssh -fNL 3333:localhost:3333 lba-1
-```
+**Browser flow (alternative, for localhost only):**
+Start the auth server with `npm run auth-server` — needs `OUTLOOK_CLIENT_ID`/`OUTLOOK_CLIENT_SECRET` as env vars. The MCP server itself reads credentials from `.mcp.json` inline `kc_get` calls. Full walkthrough: [`docs/how-to/getting-started/connect-outlook-to-claude.md`](docs/how-to/getting-started/connect-outlook-to-claude.md).
 
 **Token refresh**: Tokens auto-refresh when expired (via `token-storage.js`). Re-authentication only needed when the refresh token expires (~90 days).
 
@@ -124,23 +110,7 @@ OUTLOOK_AUTH_METHOD=device-code            # Optional: default auth method (devi
 
 ## Common Issues
 
-| Issue | Solution |
-|-------|----------|
-| `AADSTS7000215` (invalid secret) | Use secret **VALUE**, not Secret ID from Azure |
-| `EADDRINUSE :3333` | `npx kill-port 3333` then restart auth server |
-| Module not found | Run `npm install` |
-| Auth URL doesn't work | Start auth server first: `npm run auth-server` |
-| Empty API response | Check auth status with `auth` tool (action=status) |
-| `search-emails` returns no results | On personal accounts, `query` auto-falls back to subject search (v3.5.2). Use `subject`, `from`, `to`, `receivedAfter` filters for best results |
-| `create-event` wrong timezone | Omit the `Z` suffix on times for local timezone. `Z` suffix = UTC, which may be hours off |
-| Auth server "missing client ID" | Ensure `OUTLOOK_CLIENT_ID`/`OUTLOOK_CLIENT_SECRET` are set as env vars for the auth server process |
-| Device code "invalid_client" | Enable "Allow public client flows" in Azure Portal > App registrations > Authentication |
-| Device code sign-in shows "wrongplace" | Normal — sign-in completed. Close the browser, call `device-code-complete` |
-| Device code sign-in redirects to localhost | Use incognito/private browser for `microsoft.com/devicelogin` |
-| `device-code-complete` hangs | Tool is polling (not a permission prompt). Wait 10-15s. If still hanging, sign-in didn't complete — get new code, use incognito browser |
-| `device-code-complete` "no pending flow" | Fixed in v3.7.2 — device code state now persists to disk, surviving MCP server restarts. Update to v3.7.2+ |
-| Token refresh fails after ~60 min (device code) | Fixed in v3.7.2 — earlier versions sent `client_secret` for public client refresh. Update to v3.7.2+ |
-| `search-emails` returns 503 error | Fixed in v3.5.2 — `query` now falls back to `contains(subject)` on personal accounts. For body search, use `kqlQuery` (#98) |
+Common errors (auth, device code, search, timezones) and fixes live in [`docs/troubleshooting.md`](docs/troubleshooting.md).
 
 ## Testing
 
@@ -166,6 +136,7 @@ Mock data defined in `utils/mock-data.js`.
 
 - [`README.md`](README.md) - Full documentation, Azure setup, tool reference
 - [`docs/architecture.md`](docs/architecture.md) - Module layout, file tree, tool-consolidation map, history
+- [`docs/troubleshooting.md`](docs/troubleshooting.md) - Common issues and fixes
 - [`docs/quickrefs/tools-reference.md`](docs/quickrefs/tools-reference.md) - Tools quick reference
 - `.env.example` - Environment template
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,51 @@
+# Troubleshooting
+
+Common issues and their fixes. For getting-started guidance, see [`docs/how-to/getting-started/`](how-to/getting-started/). For architecture and module layout, see [`docs/architecture.md`](architecture.md).
+
+## Common Issues
+
+| Issue | Solution |
+|-------|----------|
+| `AADSTS7000215` (invalid secret) | Use secret **VALUE**, not Secret ID from Azure |
+| `EADDRINUSE :3333` | `npx kill-port 3333` then restart auth server |
+| Module not found | Run `npm install` |
+| Auth URL doesn't work | Start auth server first: `npm run auth-server` |
+| Empty API response | Check auth status with `auth` tool (action=status) |
+| `search-emails` returns no results | On personal accounts, `query` auto-falls back to subject search (v3.5.2). Use `subject`, `from`, `to`, `receivedAfter` filters for best results |
+| `create-event` wrong timezone | Omit the `Z` suffix on times for local timezone. `Z` suffix = UTC, which may be hours off |
+| Auth server "missing client ID" | Ensure `OUTLOOK_CLIENT_ID`/`OUTLOOK_CLIENT_SECRET` are set as env vars for the auth server process |
+| Device code "invalid_client" | Enable "Allow public client flows" in Azure Portal > App registrations > Authentication |
+| Device code sign-in shows "wrongplace" | Normal — sign-in completed. Close the browser, call `device-code-complete` |
+| Device code sign-in redirects to localhost | Use incognito/private browser for `microsoft.com/devicelogin` |
+| `device-code-complete` hangs | Tool is polling (not a permission prompt). Wait 10-15s. If still hanging, sign-in didn't complete — get new code, use incognito browser |
+| `device-code-complete` "no pending flow" | Fixed in v3.7.2 — device code state now persists to disk, surviving MCP server restarts. Update to v3.7.2+ |
+| Token refresh fails after ~60 min (device code) | Fixed in v3.7.2 — earlier versions sent `client_secret` for public client refresh. Update to v3.7.2+ |
+| `search-emails` returns 503 error | Fixed in v3.5.2 — `query` now falls back to `contains(subject)` on personal accounts. For body search, use `kqlQuery` (#98) |
+
+## Checking Authentication State
+
+```bash
+# Token state (redacted)
+cat ~/.outlook-assistant-tokens.json | python3 -c "import json,sys; t=json.load(sys.stdin); print('auth_method:', t.get('auth_method')); print('expires_at:', t.get('expires_at')); print('has access_token:', bool(t.get('access_token')))"
+
+# Pending device-code state (only present between authenticate and device-code-complete)
+ls -la ~/.outlook-assistant-pending-auth.json 2>/dev/null || echo "No pending flow"
+```
+
+## Forcing a Fresh Auth
+
+If tokens are corrupted or stuck:
+
+```bash
+rm ~/.outlook-assistant-tokens.json ~/.outlook-assistant-pending-auth.json
+# Then call the auth tool again with action=authenticate
+```
+
+## Reporting Issues
+
+Report issues at <https://github.com/littlebearapps/outlook-assistant/issues> with:
+
+- Error message (full text)
+- Contents of the token file (redact `access_token` and `refresh_token`)
+- Auth method: device code or browser
+- Account type: personal (Microsoft/Outlook.com) or work/school


### PR DESCRIPTION
## Summary

Follow-up to #145 (v3.7.2 auth docs) and b5a74b8 (architecture extraction). Brings CLAUDE.md under the 160-line canonical context budget and promotes operational content to docs/.

- Extract the 14-row Common Issues table into **new** `docs/troubleshooting.md` — replaced in CLAUDE.md with a one-line pointer.
- Slim the verbose "Browser flow (alternative, for localhost use)" subsection (18 lines of `kc_get` env wiring + SSH-tunnel instructions) to a two-line pointer at `docs/how-to/getting-started/connect-outlook-to-claude.md` (where the full walkthrough already lives).
- Add `docs/troubleshooting.md` link to the "See Also" section.

## Metrics

| Metric | Before | After | Delta |
|---|---|---|---|
| CLAUDE.md lines | 175 | 146 | -29 |
| CLAUDE.md lines since v3.7.2 refresh began | 234 | 146 | -88 (-38%) |
| Context health score (internal) | ~85 | ~97 | +12, grade A |

## No runtime changes
- Docs-only — no code touched, no tests needed.
- Publish workflow triggers only on `v*` tags → no npm publish from this PR.
- No package.json version bump required.

## Test plan
- [x] CLAUDE.md renders correctly with all section pointers resolving
- [x] docs/troubleshooting.md and docs/how-to/getting-started/connect-outlook-to-claude.md exist on disk
- [ ] CI green (lint, format, tests — none should be affected by doc-only changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Streamlined browser authentication setup instructions for easier configuration.
  * Created centralized troubleshooting guide addressing common issues including authentication errors, server conflicts, and missing dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->