### PR TITLE
fix(ci): notify-website didn't fire on auto-tagged releases

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -94,3 +94,17 @@ jobs:
           TAG="v${{ steps.version.outputs.current }}"
           gh workflow run publish.yml --ref "$TAG"
           echo "Triggered publish workflow for $TAG"
+
+      - name: Trigger website notification
+        # Releases created by GITHUB_TOKEN don't fire the `release: published`
+        # event (infinite-loop prevention), so notify-website.yml needs to be
+        # dispatched explicitly. Same workaround pattern as the publish step
+        # above. workflow_dispatch IS exempt from the GITHUB_TOKEN trigger
+        # restriction, so this works without a PAT.
+        if: steps.version.outputs.changed == 'true' && steps.check-tag.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="v${{ steps.version.outputs.current }}"
+          gh workflow run notify-website.yml --ref main -f tag="$TAG"
+          echo "Triggered notify-website workflow for $TAG"

--- a/.github/workflows/notify-website.yml
+++ b/.github/workflows/notify-website.yml
@@ -2,10 +2,27 @@ name: Notify Website
 
 # Triggers a rebuild of littlebearapps.com when a new release is published,
 # so version badges and changelogs update automatically.
+#
+# Triggers:
+# 1. release: published (legacy / external manual releases)
+# 2. workflow_dispatch (chained from auto-tag.yml — GITHUB_TOKEN-created
+#    releases do NOT fire the `release: published` event because of
+#    GitHub's infinite-loop prevention, so auto-tag dispatches this
+#    workflow explicitly. workflow_dispatch IS exempt from that
+#    restriction. Same workaround pattern as publish.yml.)
+#
+# Manual retroactive trigger:
+#   gh workflow run notify-website.yml -f tag=v3.7.4
 
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to notify the website about (e.g. v3.7.4)'
+        required: true
+        type: string
 
 permissions: {} # No GITHUB_TOKEN scopes needed — uses external WEBSITE_DISPATCH_TOKEN
 
@@ -13,10 +30,28 @@ jobs:
   notify:
     runs-on: ubuntu-latest
     steps:
+      - name: Resolve tag
+        id: tag
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          DISPATCH_TAG: ${{ github.event.inputs.tag }}
+        run: |
+          # Prefer the release-event tag; fall back to the dispatch input.
+          TAG="${RELEASE_TAG:-$DISPATCH_TAG}"
+          if [ -z "$TAG" ]; then
+            echo "::error::no tag available from event payload or workflow_dispatch input"
+            exit 1
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "Using tag: $TAG"
+
       - name: Trigger website rebuild
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+          DISPATCH_TOKEN: ${{ secrets.WEBSITE_DISPATCH_TOKEN }}
         run: |
           curl -s -X POST \
             -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ secrets.WEBSITE_DISPATCH_TOKEN }}" \
+            -H "Authorization: Bearer $DISPATCH_TOKEN" \
             https://api.github.com/repos/littlebearapps/littlebearapps.com/dispatches \
-            -d '{"event_type":"release-published","client_payload":{"repo":"outlook-assistant","tag":"${{ github.event.release.tag_name }}"}}'
+            -d "$(jq -n --arg tag "$TAG" '{event_type:"release-published",client_payload:{repo:"outlook-assistant",tag:$tag}}')"


### PR DESCRIPTION
## Summary

`notify-website.yml` hasn't run since March 2026, despite v3.7.1, v3.7.2, v3.7.3, and v3.7.4 all shipping in that window.

**Root cause**: `auto-tag.yml` creates the GitHub Release via `gh release create` using the default `GITHUB_TOKEN`. **Releases published by `GITHUB_TOKEN` do not fire the `release: published` event** — that's GitHub's infinite-loop prevention. `notify-website.yml` only listens on `release: published`, so it never ran.

The same restriction is exactly why `publish.yml` is dispatched explicitly via `workflow_dispatch` from `auto-tag.yml` (per the comment in `auto-tag.yml`'s header). `notify-website.yml` was missing that workaround.

## Fix

- **`.github/workflows/notify-website.yml`** — adds a `workflow_dispatch` trigger with a `tag` input. Keeps the legacy `release: published` trigger as a defensive fallback (in case someone uses `gh release create` directly outside the auto-tag chain). New "Resolve tag" step prefers the release-event tag and falls back to the dispatch input.
- **`.github/workflows/auto-tag.yml`** — adds a step after the publish dispatch that runs `gh workflow run notify-website.yml --ref main -f tag="$TAG"`. The full chain is now:
  ```
  version bump → auto-tag → tag + Release → publish.yml
                                          → notify-website.yml
  ```

Both downstream workflows are now dispatched explicitly. `workflow_dispatch` IS exempt from the `GITHUB_TOKEN` trigger restriction, so this works without a PAT.

## Hardening (drive-by)

- Dispatch token (`WEBSITE_DISPATCH_TOKEN`) now passed via `env:` rather than inline `${{ secrets... }}` interpolation in the run command body.
- JSON payload built with `jq -n --arg` instead of shell-quoted template literals — eliminates the (small) injection surface from a tag containing unusual characters.

## Manual retroactive trigger

After merge, I'll run this for v3.7.4 (the release that motivated this PR) so the website rebuild fires for the current version:

```
gh workflow run notify-website.yml -f tag=v3.7.4
```

## Test plan

- [ ] CI: lint-workflows (actionlint), lint-code, test matrix, security audit, dependency review, commitlint
- [ ] After merge, `gh workflow run notify-website.yml -f tag=v3.7.4` succeeds and the website-side `release-published` repository_dispatch event fires
- [ ] Next release (v3.7.5 / v3.8.0): notify-website appears in the workflow runs list under the auto-tag dispatch chain

🤖 Generated with [Claude Code](https://claude.com/claude-code)