### PR TITLE
docs(readme): use absolute URLs for demo gif/mp4 so npm renders them

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ Outlook Assistant connects AI assistants to your Microsoft Outlook account throu
 
 <div align="center">
   <br />
-  <a href="docs/demo/outlook-assistant-demo.mp4">
-    <img src="docs/demo/outlook-assistant-demo.gif" alt="Outlook Assistant Demo — searching emails, reading, and drafting a reply" width="720" style="border-radius: 12px; box-shadow: 0 8px 32px rgba(0,0,0,0.12);" />
+  <a href="https://github.com/littlebearapps/outlook-assistant/blob/main/docs/demo/outlook-assistant-demo.mp4">
+    <img src="https://raw.githubusercontent.com/littlebearapps/outlook-assistant/main/docs/demo/outlook-assistant-demo.gif" alt="Outlook Assistant Demo — searching emails, reading, and drafting a reply" width="720" style="border-radius: 12px; box-shadow: 0 8px 32px rgba(0,0,0,0.12);" />
   </a>
   <br />
   <sub>Search inbox → read &amp; summarise → draft a reply — all from the conversation</sub>


### PR DESCRIPTION
## Summary

- Switches the centred-hero demo `<img src>` / `<a href>` from relative `docs/demo/...` paths to absolute `raw.githubusercontent.com` / `github.com/blob/main` URLs.
- Fixes broken demo rendering on npmjs.com and other package registries, where the published tarball has no `docs/` directory (excluded via `package.json` `files`) and relative-path rewriting inside `<div align="center">…</div>` is inconsistent across registries.
- No `package.json` change — keeping `docs/` out of the tarball is correct (the gif alone is 3.3 MB).

The new URLs match the logo URL pattern already used on line 2 of the README.

Refs: regression noticed after the v3.7.4 publish — the absolute logo + badges have always rendered, but the demo block has been broken on npm since `feat: add demo GIF/MP4 to README` (50f0aca).

## Test plan

- [x] `curl -sIL https://raw.githubusercontent.com/littlebearapps/outlook-assistant/main/docs/demo/outlook-assistant-demo.gif` → `HTTP/2 200`, `content-type: image/gif`.
- [x] `curl -sIL https://github.com/littlebearapps/outlook-assistant/blob/main/docs/demo/outlook-assistant-demo.mp4` → `HTTP/2 200` (preview page).
- [x] Local grep confirms no remaining relative `src=` / `href=` image refs in `README.md`.
- [ ] After merge: verify GitHub README renders identically (raw URLs render the same as relative paths on GitHub).
- [ ] After next publish (v3.7.5): verify the demo gif renders inline on `https://www.npmjs.com/package/@littlebearapps/outlook-assistant`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved demo video link accessibility by updating the reference path for better reliability and shareability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->