### PR TITLE
feat(auth): configurable OAuth audience via OUTLOOK_AUTH_AUDIENCE

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,3 +28,13 @@ USE_TEST_MODE=false
 # device-code: No auth server needed, works remotely/headless
 # browser: Traditional OAuth redirect via localhost:3333
 # OUTLOOK_AUTH_METHOD=device-code
+
+# Optional: OAuth audience — controls which Microsoft Identity Platform
+# endpoint is used. Must match the Azure app registration's "Supported
+# account types" setting:
+#   common         — personal AND work/school accounts (default; multi-tenant + personal apps)
+#   consumers      — personal Microsoft accounts only
+#   organizations  — work/school accounts only
+#   <tenant-guid>  — single-tenant
+# Example: OUTLOOK_AUTH_AUDIENCE=consumers   (for personal-account-only apps)
+# OUTLOOK_AUTH_AUDIENCE=common

--- a/config.js
+++ b/config.js
@@ -42,6 +42,29 @@ if (!homeDir) {
  */
 const AUTH_AUDIENCE = process.env.OUTLOOK_AUTH_AUDIENCE || 'common';
 
+// Surface obvious misconfigurations at startup rather than failing later with a
+// cryptic AADSTS error from Microsoft. Warn rather than throw so we never break
+// an existing deployment on upgrade — Graph itself remains the source of truth
+// for what audiences it accepts.
+const VALID_AUDIENCE_LITERALS = new Set([
+  'common',
+  'consumers',
+  'organizations',
+]);
+const TENANT_GUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+if (
+  !VALID_AUDIENCE_LITERALS.has(AUTH_AUDIENCE) &&
+  !TENANT_GUID_RE.test(AUTH_AUDIENCE)
+) {
+  // eslint-disable-next-line no-console
+  console.warn(
+    `[outlook-assistant] OUTLOOK_AUTH_AUDIENCE="${AUTH_AUDIENCE}" is not a recognised value. ` +
+      `Expected one of: common, consumers, organizations, or a tenant GUID. ` +
+      `Proceeding anyway — Microsoft's identity platform will reject it at runtime if invalid.`
+  );
+}
+
 module.exports = {
   // Server information
   SERVER_NAME: 'outlook-assistant',

--- a/config.js
+++ b/config.js
@@ -23,6 +23,25 @@ if (!homeDir) {
   );
 }
 
+/**
+ * Resolve the OAuth audience segment used in Microsoft Graph endpoints.
+ *
+ * Microsoft's identity platform v2.0 routes by audience:
+ *   - `common`         — personal AND work/school accounts (multi-tenant + personal)
+ *   - `consumers`      — personal Microsoft accounts only
+ *   - `organizations`  — work/school accounts only
+ *   - `<tenant-guid>`  — single-tenant
+ *
+ * The right value depends on the Azure app registration's "Supported account
+ * types" setting. An app registered as "Personal Microsoft accounts only" is
+ * rejected by `/common/` with `AADSTS9002331` and must use `/consumers/`;
+ * a single-tenant app must use its tenant GUID; etc.
+ *
+ * Defaulting to `common` preserves existing behaviour. Set
+ * `OUTLOOK_AUTH_AUDIENCE` to override.
+ */
+const AUTH_AUDIENCE = process.env.OUTLOOK_AUTH_AUDIENCE || 'common';
+
 module.exports = {
   // Server information
   SERVER_NAME: 'outlook-assistant',
@@ -54,9 +73,10 @@ module.exports = {
     ],
     tokenStorePath: path.join(homeDir, '.outlook-assistant-tokens.json'),
     authServerUrl: 'http://localhost:3333',
-    deviceCodeEndpoint:
-      'https://login.microsoftonline.com/common/oauth2/v2.0/devicecode',
-    tokenEndpoint: 'https://login.microsoftonline.com/common/oauth2/v2.0/token',
+    audience: AUTH_AUDIENCE,
+    deviceCodeEndpoint: `https://login.microsoftonline.com/${AUTH_AUDIENCE}/oauth2/v2.0/devicecode`,
+    tokenEndpoint: `https://login.microsoftonline.com/${AUTH_AUDIENCE}/oauth2/v2.0/token`,
+    authorizeEndpoint: `https://login.microsoftonline.com/${AUTH_AUDIENCE}/oauth2/v2.0/authorize`,
     defaultAuthMethod: process.env.OUTLOOK_AUTH_METHOD || 'device-code',
   },
 

--- a/outlook-auth-server.js
+++ b/outlook-auth-server.js
@@ -247,7 +247,9 @@ const server = http.createServer((req, res) => {
       state,
     };
 
-    const authUrl = `https://login.microsoftonline.com/common/oauth2/v2.0/authorize?${querystring.stringify(authParams)}`;
+    // Use the audience from config (defaults to "common"; configurable via
+    // OUTLOOK_AUTH_AUDIENCE for personal-only / single-tenant Azure apps).
+    const authUrl = `${AUTH_CONFIG.authorizeEndpoint}?${querystring.stringify(authParams)}`;
     console.log(`Redirecting to: ${authUrl}`);
 
     // Redirect to Microsoft's login page
@@ -296,9 +298,11 @@ function exchangeCodeForTokens(code) {
       scope: AUTH_CONFIG.scopes.join(' '),
     });
 
+    // Same audience-driven path as the authorize URL above.
+    const tokenUrl = new URL(AUTH_CONFIG.tokenEndpoint);
     const options = {
-      hostname: 'login.microsoftonline.com',
-      path: '/common/oauth2/v2.0/token',
+      hostname: tokenUrl.hostname,
+      path: tokenUrl.pathname,
       method: 'POST',
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded',

--- a/outlook-auth-server.js
+++ b/outlook-auth-server.js
@@ -39,7 +39,8 @@ const { AUTH_CONFIG: centralAuth } = require('./config');
 // Log to console
 console.log('Starting Outlook Authentication Server');
 
-// Authentication configuration — scopes and tokenStorePath from config.js (single source of truth)
+// Authentication configuration — scopes, tokenStorePath, and audience-driven
+// endpoints sourced from config.js (single source of truth).
 const AUTH_CONFIG = {
   clientId: process.env.OUTLOOK_CLIENT_ID || process.env.MS_CLIENT_ID || '',
   clientSecret:
@@ -47,6 +48,8 @@ const AUTH_CONFIG = {
   redirectUri: centralAuth.redirectUri,
   scopes: centralAuth.scopes,
   tokenStorePath: centralAuth.tokenStorePath,
+  authorizeEndpoint: centralAuth.authorizeEndpoint,
+  tokenEndpoint: centralAuth.tokenEndpoint,
 };
 
 // Create HTTP server

--- a/outlook-auth-server.js
+++ b/outlook-auth-server.js
@@ -305,7 +305,9 @@ function exchangeCodeForTokens(code) {
     const tokenUrl = new URL(AUTH_CONFIG.tokenEndpoint);
     const options = {
       hostname: tokenUrl.hostname,
-      path: tokenUrl.pathname,
+      // Preserve any query string on the endpoint (none today, but future-safe
+      // if Microsoft ever adds hint params to the token URL).
+      path: tokenUrl.pathname + tokenUrl.search,
       method: 'POST',
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded',

--- a/test/auth/audience.test.js
+++ b/test/auth/audience.test.js
@@ -1,0 +1,77 @@
+/**
+ * Tests for OUTLOOK_AUTH_AUDIENCE — the configurable OAuth audience that
+ * picks which segment is used in the Microsoft login URLs:
+ *   common (default), consumers, organizations, <tenant-guid>
+ */
+
+describe('OUTLOOK_AUTH_AUDIENCE', () => {
+  let originalAudience;
+
+  beforeEach(() => {
+    originalAudience = process.env.OUTLOOK_AUTH_AUDIENCE;
+    // Force a fresh load of config.js — Node caches required modules,
+    // so without this the env var change wouldn't take effect.
+    jest.resetModules();
+  });
+
+  afterEach(() => {
+    if (originalAudience === undefined) {
+      delete process.env.OUTLOOK_AUTH_AUDIENCE;
+    } else {
+      process.env.OUTLOOK_AUTH_AUDIENCE = originalAudience;
+    }
+    jest.resetModules();
+  });
+
+  test('defaults to "common" when env var is unset', () => {
+    delete process.env.OUTLOOK_AUTH_AUDIENCE;
+    const { AUTH_CONFIG } = require('../../config');
+    expect(AUTH_CONFIG.audience).toBe('common');
+    expect(AUTH_CONFIG.tokenEndpoint).toBe(
+      'https://login.microsoftonline.com/common/oauth2/v2.0/token'
+    );
+    expect(AUTH_CONFIG.deviceCodeEndpoint).toBe(
+      'https://login.microsoftonline.com/common/oauth2/v2.0/devicecode'
+    );
+    expect(AUTH_CONFIG.authorizeEndpoint).toBe(
+      'https://login.microsoftonline.com/common/oauth2/v2.0/authorize'
+    );
+  });
+
+  test('routes to /consumers/ for personal-only apps', () => {
+    process.env.OUTLOOK_AUTH_AUDIENCE = 'consumers';
+    const { AUTH_CONFIG } = require('../../config');
+    expect(AUTH_CONFIG.audience).toBe('consumers');
+    expect(AUTH_CONFIG.tokenEndpoint).toBe(
+      'https://login.microsoftonline.com/consumers/oauth2/v2.0/token'
+    );
+    expect(AUTH_CONFIG.deviceCodeEndpoint).toBe(
+      'https://login.microsoftonline.com/consumers/oauth2/v2.0/devicecode'
+    );
+    expect(AUTH_CONFIG.authorizeEndpoint).toBe(
+      'https://login.microsoftonline.com/consumers/oauth2/v2.0/authorize'
+    );
+  });
+
+  test('routes to /organizations/ for work/school-only apps', () => {
+    process.env.OUTLOOK_AUTH_AUDIENCE = 'organizations';
+    const { AUTH_CONFIG } = require('../../config');
+    expect(AUTH_CONFIG.audience).toBe('organizations');
+    expect(AUTH_CONFIG.tokenEndpoint).toBe(
+      'https://login.microsoftonline.com/organizations/oauth2/v2.0/token'
+    );
+  });
+
+  test('accepts a tenant GUID for single-tenant apps', () => {
+    const tenantId = '11111111-2222-3333-4444-555555555555';
+    process.env.OUTLOOK_AUTH_AUDIENCE = tenantId;
+    const { AUTH_CONFIG } = require('../../config');
+    expect(AUTH_CONFIG.audience).toBe(tenantId);
+    expect(AUTH_CONFIG.tokenEndpoint).toBe(
+      `https://login.microsoftonline.com/${tenantId}/oauth2/v2.0/token`
+    );
+    expect(AUTH_CONFIG.authorizeEndpoint).toBe(
+      `https://login.microsoftonline.com/${tenantId}/oauth2/v2.0/authorize`
+    );
+  });
+});

--- a/test/auth/audience.test.js
+++ b/test/auth/audience.test.js
@@ -60,6 +60,12 @@ describe('OUTLOOK_AUTH_AUDIENCE', () => {
     expect(AUTH_CONFIG.tokenEndpoint).toBe(
       'https://login.microsoftonline.com/organizations/oauth2/v2.0/token'
     );
+    expect(AUTH_CONFIG.deviceCodeEndpoint).toBe(
+      'https://login.microsoftonline.com/organizations/oauth2/v2.0/devicecode'
+    );
+    expect(AUTH_CONFIG.authorizeEndpoint).toBe(
+      'https://login.microsoftonline.com/organizations/oauth2/v2.0/authorize'
+    );
   });
 
   test('accepts a tenant GUID for single-tenant apps', () => {
@@ -69,6 +75,9 @@ describe('OUTLOOK_AUTH_AUDIENCE', () => {
     expect(AUTH_CONFIG.audience).toBe(tenantId);
     expect(AUTH_CONFIG.tokenEndpoint).toBe(
       `https://login.microsoftonline.com/${tenantId}/oauth2/v2.0/token`
+    );
+    expect(AUTH_CONFIG.deviceCodeEndpoint).toBe(
+      `https://login.microsoftonline.com/${tenantId}/oauth2/v2.0/devicecode`
     );
     expect(AUTH_CONFIG.authorizeEndpoint).toBe(
       `https://login.microsoftonline.com/${tenantId}/oauth2/v2.0/authorize`

--- a/test/auth/audience.test.js
+++ b/test/auth/audience.test.js
@@ -83,4 +83,49 @@ describe('OUTLOOK_AUTH_AUDIENCE', () => {
       `https://login.microsoftonline.com/${tenantId}/oauth2/v2.0/authorize`
     );
   });
+
+  describe('startup validation', () => {
+    let warnSpy;
+
+    beforeEach(() => {
+      warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      warnSpy.mockRestore();
+    });
+
+    test('warns on unrecognised value (typo)', () => {
+      process.env.OUTLOOK_AUTH_AUDIENCE = 'not-a-tenant';
+      require('../../config');
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0][0]).toMatch(/OUTLOOK_AUTH_AUDIENCE/);
+      expect(warnSpy.mock.calls[0][0]).toMatch(/not-a-tenant/);
+    });
+
+    test('does not warn on the four valid forms', () => {
+      const valid = [
+        undefined, // default -> 'common'
+        'common',
+        'consumers',
+        'organizations',
+        '11111111-2222-3333-4444-555555555555',
+      ];
+      for (const v of valid) {
+        warnSpy.mockClear();
+        jest.resetModules();
+        if (v === undefined) delete process.env.OUTLOOK_AUTH_AUDIENCE;
+        else process.env.OUTLOOK_AUTH_AUDIENCE = v;
+        require('../../config');
+        expect(warnSpy).not.toHaveBeenCalled();
+      }
+    });
+
+    test('warns on malformed GUID', () => {
+      // Missing one hex char in the last group — looks GUID-shaped but isn't.
+      process.env.OUTLOOK_AUTH_AUDIENCE = '11111111-2222-3333-4444-55555555555';
+      require('../../config');
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Makes the Microsoft Identity Platform OAuth audience configurable via a new `OUTLOOK_AUTH_AUDIENCE` env var, defaulting to `common` (current behaviour).

The server today hardcodes `/common/` in the OAuth endpoints. That works for the most common Azure app shape (multi-tenant + personal), but breaks two real cases:

- **Azure apps registered as "Personal Microsoft accounts only"** are rejected by `/common/` with `AADSTS9002331` ("configured for use by Microsoft Account users only. Please use the /consumers endpoint to serve this request") — they need `/consumers/` instead.
- **Single-tenant apps** need their tenant GUID rather than `/common/`.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Module(s) Affected

- [x] Auth
- [x] Utils / Config
- [x] Documentation

## What's in the patch

- **`config.js`** — reads `OUTLOOK_AUTH_AUDIENCE` (default `common`) and uses it to build `tokenEndpoint`, `deviceCodeEndpoint`, and a new `authorizeEndpoint` field on `AUTH_CONFIG`. Adds JSDoc explaining the four meaningful values.
- **`outlook-auth-server.js`** — the browser-flow auth server's authorize URL now uses `AUTH_CONFIG.authorizeEndpoint`, and the token-POST host/path are derived from `AUTH_CONFIG.tokenEndpoint` so they pick up the configured audience automatically.
- **`.env.example`** — new commented block documenting the four possible values with a worked example for personal-only apps.
- **`test/auth/audience.test.js`** — 4 tests covering: default behaviour (unset env var → `common`), `consumers`, `organizations`, and a tenant GUID. Each asserts all three derived endpoints (token, devicecode, authorize) reflect the chosen audience.

## Design notes

- **Backwards compatible.** Default audience is `common` — existing deployments unchanged.
- **`AUTH_CONFIG.audience`** exposed as a top-level field so callers / future code can introspect the configured value without re-parsing endpoints.
- **`AUTH_CONFIG.authorizeEndpoint`** added as a new field. Was previously only constructed inline in `outlook-auth-server.js`; promoting it to config makes the audience-driven derivation obvious in one place.
- **Defaults in `auth/token-storage.js` / `auth/oauth-server.js` left as `/common/`.** These are unreachable in the production code path (callers pass `tokenEndpoint` from `config.AUTH_CONFIG`), so I deliberately left them untouched to keep this PR's diff narrow. Happy to update them too if you'd prefer the consistency.

## Checklist

- [x] Tests pass (`npm test`) — 712/712 passing locally (4 new audience tests + 708 existing)
- [x] Linting passes (`npm run lint`) — 0 errors (24 pre-existing warnings unchanged)
- [x] Documentation updated (.env.example)
- [ ] `docs/quickrefs/tools-reference.md` — n/a (this is config-layer, not tool-layer)
- [x] Follows code style guidelines

## Related Issues

None — opportunistic improvement after running into AADSTS9002331 on a personal-only Azure app registration.

## Test Plan

```bash
npm install
npm test
```

The new audience test file exercises every code path with `jest.resetModules()` between each test so the env-var-driven module load is exercised cleanly. End-to-end manually verified against a personal-only Azure app: setting `OUTLOOK_AUTH_AUDIENCE=consumers` made device-code authentication succeed where `/common/` had previously failed with AADSTS9002331.

## Additional Notes

This is the second of three small upstream patches I'm sending after running the server against a personal-only Azure app + UK timezone. The first was #173 (manage-event update action). The third will land separately and add `OUTLOOK_DEFAULT_TIMEZONE` for the default-timezone hardcode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OAuth authentication endpoints are now dynamically configurable based on audience settings, enabling applications to authenticate against different organizational tenants and identity providers.

* **Tests**
  * Added test coverage for audience configuration behavior, including default behavior, organization-specific routing, and tenant GUID scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->