### PR TITLE
feat(config): make DEFAULT_TIMEZONE overridable via env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,3 +28,12 @@ USE_TEST_MODE=false
 # device-code: No auth server needed, works remotely/headless
 # browser: Traditional OAuth redirect via localhost:3333
 # OUTLOOK_AUTH_METHOD=device-code
+
+# Optional: Default timezone for calendar events when not explicitly
+# specified by the caller. Use any IANA timezone identifier.
+# Default: Australia/Melbourne
+# Examples:
+#   OUTLOOK_DEFAULT_TIMEZONE=Europe/London
+#   OUTLOOK_DEFAULT_TIMEZONE=America/New_York
+#   OUTLOOK_DEFAULT_TIMEZONE=Asia/Tokyo
+# OUTLOOK_DEFAULT_TIMEZONE=Australia/Melbourne

--- a/config.js
+++ b/config.js
@@ -97,6 +97,9 @@ module.exports = {
   // Immutable IDs (opt-in: IDs persist through folder moves)
   USE_IMMUTABLE_IDS: process.env.OUTLOOK_IMMUTABLE_IDS === 'true',
 
-  // Timezone
-  DEFAULT_TIMEZONE: 'Australia/Melbourne', // Updated for Nathan's timezone
+  // Timezone — IANA zone (e.g. "Australia/Melbourne", "Europe/London",
+  // "America/New_York"). Override per-deployment via OUTLOOK_DEFAULT_TIMEZONE.
+  // Default preserves the historic value for backwards compatibility.
+  DEFAULT_TIMEZONE:
+    process.env.OUTLOOK_DEFAULT_TIMEZONE || 'Australia/Melbourne',
 };

--- a/docs/quickrefs/tools-reference.md
+++ b/docs/quickrefs/tools-reference.md
@@ -83,7 +83,7 @@ Quick reference for all 22 MCP tools across 9 modules. Each tool includes MCP sa
 | Tool | Description | Safety | Key Parameters |
 |------|-------------|--------|----------------|
 | `list-events` | List upcoming events | read-only | `count` |
-| `create-event` | Create new event | moderate write | `subject`, `start`, `end`, `attendees`, `body`. Times use configured timezone (default: Australia/Melbourne) — omit `Z` suffix for local time |
+| `create-event` | Create new event | moderate write | `subject`, `start`, `end`, `attendees`, `body`. Times use configured timezone (default: Australia/Melbourne; override with `OUTLOOK_DEFAULT_TIMEZONE` env var) — omit `Z` suffix for local time |
 | `manage-event` | Decline, cancel, or delete | **destructive** | `action` (`decline`/`cancel`/`delete`), `eventId` (or alias `id`), `comment` |
 
 ## Folder (1 tool)

--- a/test/auth/default-timezone.test.js
+++ b/test/auth/default-timezone.test.js
@@ -1,0 +1,58 @@
+/**
+ * Tests for OUTLOOK_DEFAULT_TIMEZONE — the env-var override for the
+ * default IANA timezone applied to calendar events when the caller
+ * doesn't explicitly specify one.
+ */
+
+describe('OUTLOOK_DEFAULT_TIMEZONE', () => {
+  let originalTz;
+
+  beforeEach(() => {
+    originalTz = process.env.OUTLOOK_DEFAULT_TIMEZONE;
+    jest.resetModules();
+  });
+
+  afterEach(() => {
+    if (originalTz === undefined) {
+      delete process.env.OUTLOOK_DEFAULT_TIMEZONE;
+    } else {
+      process.env.OUTLOOK_DEFAULT_TIMEZONE = originalTz;
+    }
+    jest.resetModules();
+  });
+
+  test('defaults to Australia/Melbourne when env var is unset', () => {
+    delete process.env.OUTLOOK_DEFAULT_TIMEZONE;
+    const { DEFAULT_TIMEZONE } = require('../../config');
+    expect(DEFAULT_TIMEZONE).toBe('Australia/Melbourne');
+  });
+
+  test('honours OUTLOOK_DEFAULT_TIMEZONE when set', () => {
+    process.env.OUTLOOK_DEFAULT_TIMEZONE = 'Europe/London';
+    const { DEFAULT_TIMEZONE } = require('../../config');
+    expect(DEFAULT_TIMEZONE).toBe('Europe/London');
+  });
+
+  test('passes the configured timezone through to create-event', async () => {
+    process.env.OUTLOOK_DEFAULT_TIMEZONE = 'America/New_York';
+    jest.resetModules();
+    jest.doMock('../../utils/graph-api');
+    jest.doMock('../../auth');
+    const { callGraphAPI } = require('../../utils/graph-api');
+    const { ensureAuthenticated } = require('../../auth');
+    const handleCreateEvent = require('../../calendar/create');
+
+    ensureAuthenticated.mockResolvedValue('dummy_access_token');
+    callGraphAPI.mockResolvedValue({ id: 'evt_1' });
+
+    await handleCreateEvent({
+      subject: 'NY meeting',
+      start: '2026-06-01T09:00:00',
+      end: '2026-06-01T10:00:00',
+    });
+
+    const body = callGraphAPI.mock.calls[0][3];
+    expect(body.start.timeZone).toBe('America/New_York');
+    expect(body.end.timeZone).toBe('America/New_York');
+  });
+});


### PR DESCRIPTION
## Summary

Adds a new `OUTLOOK_DEFAULT_TIMEZONE` env var that overrides the hardcoded `Australia/Melbourne` default applied to calendar events when a caller doesn't specify one explicitly. Existing deployments are unaffected — the default behaviour is preserved.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Module(s) Affected

- [x] Calendar (consumer of `DEFAULT_TIMEZONE`)
- [x] Utils / Config
- [x] Documentation

## What's in the patch

- **`config.js`** — `DEFAULT_TIMEZONE` reads `OUTLOOK_DEFAULT_TIMEZONE`, falling back to `Australia/Melbourne`. Comment expanded to document the override and give example IANA zones.
- **`.env.example`** — new commented block documenting the env var with worked examples (Europe/London, America/New_York, Asia/Tokyo).
- **`docs/quickrefs/tools-reference.md`** — `create-event` row mentions the override env var alongside the default.
- **`test/auth/default-timezone.test.js`** — 3 tests covering: default value when unset, override when set, and end-to-end pass-through to `create-event` so the PATCH body sent to Graph reflects the configured timezone.

## Design notes

- **Backwards compatible** — default is unchanged at `Australia/Melbourne`.
- **No code changes outside `config.js`** — every existing consumer already imports `DEFAULT_TIMEZONE` from config, so the env-var read at config-load time flows naturally through all current call sites.

## Checklist

- [x] Tests pass (`npm test`) — 711/711 passing locally (3 new + 708 existing)
- [x] Linting passes (`npm run lint`) — 0 errors (24 pre-existing warnings unchanged)
- [x] Documentation updated (.env.example, tools-reference.md)
- [x] Follows code style guidelines

## Related Issues

None — opportunistic improvement.

## Test Plan

```bash
npm install
npm test
```

End-to-end manually verified by running the server with `OUTLOOK_DEFAULT_TIMEZONE=Europe/London`, creating a calendar event with no explicit timezone, and confirming the resulting Graph event was stored as Europe/London.

## Additional Notes

This is the third of three small upstream patches I've sent after running the server against a personal-only Azure app + UK timezone. The first was #173 (manage-event update action), the second was #174 (configurable OAuth audience). All three are independent and can be merged in any order.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Calendar default timezone is now configurable via the OUTLOOK_DEFAULT_TIMEZONE environment variable; falls back to Australia/Melbourne.

* **Documentation**
  * Calendar tool reference updated to document the OUTLOOK_DEFAULT_TIMEZONE override and example timezone identifiers.

* **Tests**
  * Added tests to verify default and overridden timezone behavior and ensure configured timezone is applied when creating events.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/littlebearapps/outlook-assistant/pull/175?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->