### PR TITLE
ci(publish): migrate npm publish to Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,8 @@
 # Publish to npm and MCP Registry
 #
 # Publishes the package to npm and the Official MCP Registry when a version
-# tag is pushed. Uses NPM_TOKEN for npm auth and GitHub OIDC for MCP Registry.
+# tag is pushed. Uses npm Trusted Publishing (OIDC) for npm auth and GitHub
+# OIDC for MCP Registry — no stored secrets required.
 #
 # Triggers:
 # 1. Tag push (manual): git push origin v3.4.1
@@ -10,16 +11,21 @@
 #    so auto-tag can chain into publish without needing a PAT.
 #
 # Prerequisites:
-# 1. Set NPM_TOKEN as a GitHub Actions secret (granular access token from npmjs.com)
+# 1. npm Trusted Publisher configured at
+#    https://www.npmjs.com/package/@littlebearapps/outlook-assistant/access
+#    (Settings → Trusted Publisher → GitHub Actions:
+#     org=littlebearapps, repo=outlook-assistant, workflow=publish.yml,
+#     allowed actions: publish)
 # 2. server.json with mcpName matching io.github.littlebearapps/outlook-assistant
+# 3. Node >= 22.14.0 and npm >= 11.5.1 (required for OIDC trusted publishing)
+#
+# npm auth: OIDC short-lived token. Bypasses the package's 2FA-required
+# policy by design — the OIDC token is its own auth mechanism, not a
+# token+OTP combo. Provenance attestation is automatic.
 #
 # MCP Registry auth: Uses GitHub Actions OIDC (no secrets needed).
 # The mcp-publisher CLI exchanges the workflow's OIDC token for a registry JWT.
 # Server name must match the publishing repo's GitHub owner (littlebearapps).
-#
-# Future: migrate npm to OIDC trusted publishing when npmjs.com trusted publisher
-# is configured (org=littlebearapps, repo=outlook-assistant, workflow=publish.yml)
-# and Node 24+ (npm 11.5.1+) is used.
 #
 # Note: This workflow uses no untrusted input in run commands.
 
@@ -47,7 +53,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: 20.x
+          # npm Trusted Publishing requires Node >= 22.14.0 / npm >= 11.5.1.
+          node-version: '22'
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
 
@@ -66,9 +73,11 @@ jobs:
       - name: Publish to npm
         id: npm-publish
         continue-on-error: true
-        run: npm publish --access public --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        # Under Trusted Publishing the short-lived OIDC token is minted from
+        # `permissions: id-token: write` on this job — no NODE_AUTH_TOKEN
+        # needed. `--provenance` is implied; passing it explicitly is fine
+        # but redundant.
+        run: npm publish --access public
 
       - name: Verify npm publication
         run: |


### PR DESCRIPTION
## Why

The v3.8.0 publish workflow failed with `EOTP — This operation requires a one-time password from your authenticator` because the package has 2FA enforced and granular access tokens require interactive OTP at publish time. The two options to unblock that don't involve weakening security are:

- Loosen the package's 2FA requirement (regression — tokens bypass 2FA going forward)
- Switch to **npm Trusted Publishing via OIDC** — GA since 31 July 2025

This PR takes the second route. OIDC is a separate auth mechanism (not token+OTP), so it satisfies the 2FA policy by design, and removes `NPM_TOKEN` as a long-lived attack surface.

## Changes

- `node-version`: `20.x` → `22` (npm Trusted Publishing requires Node >= 22.14.0 / npm >= 11.5.1)
- Drop `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` env on the `npm publish` step
- Drop the `--provenance` flag (provenance is implied/automatic under Trusted Publishing)
- Update workflow header comments to document the new auth model and prerequisites
- No change to MCP Registry publish step (already uses GitHub OIDC)

The workflow's `permissions: id-token: write` was already in place (needed for the MCP Registry step), so no permissions change required.

## Required one-time action on npmjs.com

After this merges, before re-running the publish workflow:

1. Go to https://www.npmjs.com/package/@littlebearapps/outlook-assistant/access
2. Settings → **Trusted Publisher** section → **Add Trusted Publisher**
3. Publisher: **GitHub Actions**
4. Organisation: `littlebearapps`
5. Repository: `outlook-assistant`
6. Workflow filename: `publish.yml` (just the filename, no path)
7. Environment: leave blank
8. Allowed actions: select `publish`
9. Save

## Re-publishing v3.8.0 after merge

Triggering `gh workflow run publish.yml --ref main` will run the new workflow against current main (which has v3.8.0 in `package.json`), publishing v3.8.0 via OIDC. No retag needed.

## Cleanup follow-up

Once the publish succeeds:
- Delete the now-unused `NPM_TOKEN` GitHub secret from `Settings → Secrets and variables → Actions`
- Delete/revoke the corresponding granular token from npmjs.com
- The bws `NPM_TOKEN` secret can also be removed (no longer fed anywhere)

## References

- [npm Trusted Publishers documentation](https://docs.npmjs.com/trusted-publishers/)
- [GitHub Changelog: GA announcement (Jul 2025)](https://github.blog/changelog/2025-07-31-npm-trusted-publishing-with-oidc-is-generally-available/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)