### PR TITLE
fix(ci): upgrade npm to 11.x in publish workflow for OIDC support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,10 +53,17 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          # npm Trusted Publishing requires Node >= 22.14.0 / npm >= 11.5.1.
+          # Node 22 ships with npm 10.x via the setup-node tool cache.
+          # Trusted Publishing requires npm >= 11.5.1, so we upgrade npm
+          # explicitly in the next step.
           node-version: '22'
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
+
+      - name: Upgrade npm for OIDC Trusted Publishing
+        # Node 22.22.3 bundles npm 10.9.8; OIDC Trusted Publishing needs
+        # npm >= 11.5.1. Pinned to the 11.x major for deterministic builds.
+        run: npm install --global npm@11
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Why

The OIDC migration from #189 didn't fully unblock the publish. Run [26432160814](https://github.com/littlebearapps/outlook-assistant/actions/runs/26432160814) still hit `E404` from npm:

\`\`\`
404 Not Found - PUT https://registry.npmjs.org/@littlebearapps/outlook-assistant
\`\`\`

Root cause: the runner was using **Node 22.22.3 + npm 10.9.8**. OIDC Trusted Publishing requires **npm >= 11.5.1**. \`setup-node\` uses the npm bundled with the Node tarball in its tool cache — that bundle is currently npm 10.x for the 22.22.3 cache hit, regardless of what Node version we pin.

## Fix

Add an explicit \`npm install -g npm@11\` step right after \`setup-node\` so we're guaranteed an OIDC-capable npm regardless of cache contents.

## Verification plan

1. Merge this PR
2. \`gh workflow run publish.yml --ref main\` — triggers the publish from main with current package.json (v3.8.0)
3. The \"Upgrade npm for OIDC Trusted Publishing\" step should report \`npm@11.x.y\`
4. \`npm publish\` should succeed and v3.8.0 should appear on npmjs.com

If this works, no further changes needed. If it doesn't, next likely cause is the Trusted Publisher config on npmjs.com — we'd inspect the OIDC token claims to verify the workflow path/repo match.

## Reference

[docs.npmjs.com/trusted-publishers](https://docs.npmjs.com/trusted-publishers/) — requirements section confirms Node >= 22.14.0 AND npm >= 11.5.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)