### PR TITLE
feat: add CLI version flag

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,15 @@
  * A Model Context Protocol server that provides access to
  * Microsoft Outlook through the Microsoft Graph API.
  */
+
+// Handle `--version` / `-v` before requiring anything else so we don't load
+// config, auth modules, or emit MCP startup logging just to print a version.
+if (process.argv.includes('--version') || process.argv.includes('-v')) {
+  const pkg = require('./package.json');
+  process.stdout.write(`${pkg.name} v${pkg.version}\n`);
+  process.exit(0);
+}
+
 const { Server } = require('@modelcontextprotocol/sdk/server/index.js');
 const {
   StdioServerTransport,

--- a/test/cli-version.test.js
+++ b/test/cli-version.test.js
@@ -1,0 +1,41 @@
+/**
+ * Tests for `--version` / `-v` CLI flag (GH #68).
+ *
+ * Spawns `node index.js` with the flag and asserts:
+ *   - stdout matches `@littlebearapps/outlook-assistant v<version>`
+ *   - exit code is 0
+ *   - no MCP startup output is emitted (we exit before logging)
+ */
+
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const ENTRY = path.join(__dirname, '..', 'index.js');
+const pkg = require('../package.json');
+
+function runCli(args) {
+  return spawnSync(process.execPath, [ENTRY, ...args], {
+    encoding: 'utf8',
+    timeout: 10_000,
+  });
+}
+
+describe('CLI --version flag', () => {
+  test('--version prints "<name> v<version>" and exits 0', () => {
+    const result = runCli(['--version']);
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe(`${pkg.name} v${pkg.version}`);
+  });
+
+  test('-v shorthand prints "<name> v<version>" and exits 0', () => {
+    const result = runCli(['-v']);
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe(`${pkg.name} v${pkg.version}`);
+  });
+
+  test('--version exits before MCP server startup logging', () => {
+    const result = runCli(['--version']);
+    expect(result.stderr).not.toMatch(/STARTING/);
+    expect(result.stderr).not.toMatch(/connected and listening/);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a `--version` / `-v` CLI guard to the `outlook-assistant` entrypoint so operators can check the installed package version without starting the MCP server. The flag reads `package.json`, prints `@littlebearapps/outlook-assistant v<version>`, and exits before config/module loading or startup logs.

Closes #68.

## Verification

- `npm test -- test/cli-version.test.js --runInBand`
- `node index.js --version`
- `node index.js -v`
- `npm run lint` (0 errors; existing warnings unchanged)
- `npm run format:check`
- `git diff --check`
- `npm test -- --runInBand`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--version` and `-v` CLI flags to display the server package name and version information.

* **Tests**
  * Added test suite validating CLI version flag behavior and output formatting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/littlebearapps/outlook-assistant/pull/192?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->