### PR TITLE
feat(calendar): add startAfter/startBefore/subject filters to list-events

### DIFF
--- a/calendar/index.js
+++ b/calendar/index.js
@@ -13,7 +13,7 @@ const calendarTools = [
   {
     name: 'list-events',
     description:
-      'List upcoming calendar events for the signed-in user (read-only). Returns an array of events with id, subject, start/end, attendees, location, organiser, and webLink. Use `count` (default 10, max 50) to control page size; this tool does not filter — use the Outlook UI or specific date ranges via Graph for filtered queries. Times are returned in the configured timezone (default Australia/Melbourne; override with `OUTLOOK_DEFAULT_TIMEZONE`).',
+      'List calendar events for the signed-in user (read-only). By default returns upcoming events (`start ≥ now`). Optional `startAfter`, `startBefore`, and `subject` filters let you search past, current, or specifically-named events; supplying any of them replaces the default "now" filter and the provided filters are AND-ed together. Returns an array of events with id, subject, start/end, attendees, location, organiser, and webLink. Use `count` (default 10, max 50) to control page size. Times are returned in the configured timezone (default Australia/Melbourne; override with `OUTLOOK_DEFAULT_TIMEZONE`).',
     annotations: {
       title: 'List Calendar Events',
       readOnlyHint: true,
@@ -25,6 +25,21 @@ const calendarTools = [
         count: {
           type: 'number',
           description: 'Number of events to retrieve (default: 10, max: 50)',
+        },
+        startAfter: {
+          type: 'string',
+          description:
+            'Optional ISO 8601 datetime. Only return events whose start is on or after this time. Replaces the default "now" lower bound when supplied. Example: "2026-01-01T00:00:00Z".',
+        },
+        startBefore: {
+          type: 'string',
+          description:
+            'Optional ISO 8601 datetime. Only return events whose start is strictly before this time. Combine with `startAfter` to bound a window. Example: "2026-02-01T00:00:00Z".',
+        },
+        subject: {
+          type: 'string',
+          description:
+            'Optional substring to match against the event subject (case-insensitive via Graph `contains()`). Useful for finding past or current events by name.',
         },
       },
       additionalProperties: false,

--- a/calendar/index.js
+++ b/calendar/index.js
@@ -28,11 +28,13 @@ const calendarTools = [
         },
         startAfter: {
           type: 'string',
+          format: 'date-time',
           description:
             'Optional ISO 8601 datetime. Only return events whose start is on or after this time. Replaces the default "now" lower bound when supplied. Example: "2026-01-01T00:00:00Z".',
         },
         startBefore: {
           type: 'string',
+          format: 'date-time',
           description:
             'Optional ISO 8601 datetime. Only return events whose start is strictly before this time. Combine with `startAfter` to bound a window. Example: "2026-02-01T00:00:00Z".',
         },

--- a/calendar/list.js
+++ b/calendar/list.js
@@ -10,6 +10,20 @@ const {
 } = require('../utils/odata-helpers');
 
 /**
+ * Validate that a value parses as an ISO 8601 datetime. Throws otherwise.
+ * The schema declares `format: "date-time"` but the MCP schema-coerce layer
+ * does not enforce JSON Schema `format`, so we enforce here at runtime.
+ */
+function assertIsoDateTime(value, paramName) {
+  const parsed = Date.parse(value);
+  if (Number.isNaN(parsed)) {
+    throw new Error(
+      `Invalid ${paramName}: "${value}" is not a valid ISO 8601 datetime (e.g. "2026-01-01T00:00:00Z").`
+    );
+  }
+}
+
+/**
  * Build the $filter clause for the list-events Graph query.
  *
  * Backward-compatible behaviour: when no search args are supplied, the filter
@@ -17,8 +31,9 @@ const {
  * seeing only upcoming events. When ANY of startAfter/startBefore/subject are
  * supplied, those replace the default and are AND-ed together.
  *
- * Single quotes in user-supplied strings are escaped via OData rules
- * (`'` -> `''`) to prevent filter injection.
+ * startAfter/startBefore are validated as ISO 8601 datetimes; invalid values
+ * raise before any Graph call is made. Single quotes in user-supplied strings
+ * are escaped via OData rules (`'` -> `''`) to prevent filter injection.
  *
  * @param {object} args - { startAfter?, startBefore?, subject? }
  * @returns {string} - The complete $filter expression
@@ -31,9 +46,11 @@ function buildListEventsFilter(args) {
 
   if (hasAnyFilter) {
     if (startAfter) {
+      assertIsoDateTime(startAfter, 'startAfter');
       conditions.push(`start/dateTime ge '${escapeODataString(startAfter)}'`);
     }
     if (startBefore) {
+      assertIsoDateTime(startBefore, 'startBefore');
       conditions.push(`start/dateTime lt '${escapeODataString(startBefore)}'`);
     }
     if (subject) {

--- a/calendar/list.js
+++ b/calendar/list.js
@@ -4,6 +4,47 @@
 const config = require('../config');
 const { callGraphAPI } = require('../utils/graph-api');
 const { ensureAuthenticated } = require('../auth');
+const {
+  escapeODataString,
+  buildODataFilter,
+} = require('../utils/odata-helpers');
+
+/**
+ * Build the $filter clause for the list-events Graph query.
+ *
+ * Backward-compatible behaviour: when no search args are supplied, the filter
+ * defaults to `start/dateTime ge '<now>'` so callers without parameters keep
+ * seeing only upcoming events. When ANY of startAfter/startBefore/subject are
+ * supplied, those replace the default and are AND-ed together.
+ *
+ * Single quotes in user-supplied strings are escaped via OData rules
+ * (`'` -> `''`) to prevent filter injection.
+ *
+ * @param {object} args - { startAfter?, startBefore?, subject? }
+ * @returns {string} - The complete $filter expression
+ */
+function buildListEventsFilter(args) {
+  const { startAfter, startBefore, subject } = args;
+  const hasAnyFilter = Boolean(startAfter || startBefore || subject);
+
+  const conditions = [];
+
+  if (hasAnyFilter) {
+    if (startAfter) {
+      conditions.push(`start/dateTime ge '${escapeODataString(startAfter)}'`);
+    }
+    if (startBefore) {
+      conditions.push(`start/dateTime lt '${escapeODataString(startBefore)}'`);
+    }
+    if (subject) {
+      conditions.push(`contains(subject, '${escapeODataString(subject)}')`);
+    }
+  } else {
+    conditions.push(`start/dateTime ge '${new Date().toISOString()}'`);
+  }
+
+  return buildODataFilter(conditions);
+}
 
 /**
  * List events handler
@@ -24,7 +65,7 @@ async function handleListEvents(args) {
     const queryParams = {
       $top: count,
       $orderby: 'start/dateTime',
-      $filter: `start/dateTime ge '${new Date().toISOString()}'`,
+      $filter: buildListEventsFilter(args),
       $select: config.CALENDAR_SELECT_FIELDS,
     };
 
@@ -106,3 +147,4 @@ async function handleListEvents(args) {
 }
 
 module.exports = handleListEvents;
+module.exports.buildListEventsFilter = buildListEventsFilter;

--- a/test/calendar/list.test.js
+++ b/test/calendar/list.test.js
@@ -138,12 +138,35 @@ describe('buildListEventsFilter — pure unit tests', () => {
     expect(ts.getTime()).toBeLessThanOrEqual(after.getTime());
   });
 
-  test('escapes single quotes in startAfter', () => {
-    // Defensive: even though ISO timestamps don't contain quotes,
-    // we don't trust the caller's input.
-    expect(buildListEventsFilter({ startAfter: "2026-01-01' or '" })).toBe(
-      "start/dateTime ge '2026-01-01'' or '''"
+  test('rejects malformed startAfter as not-an-ISO-datetime', () => {
+    expect(() => buildListEventsFilter({ startAfter: 'not-a-date' })).toThrow(
+      /Invalid startAfter/
     );
+  });
+
+  test('rejects malformed startBefore as not-an-ISO-datetime', () => {
+    expect(() => buildListEventsFilter({ startBefore: 'tomorrow' })).toThrow(
+      /Invalid startBefore/
+    );
+  });
+
+  test('injection-style strings in startAfter are rejected before reaching OData', () => {
+    // The ISO validation is an earlier, stricter line of defence than the
+    // OData escape: anything that isn't parseable as a datetime never makes
+    // it into the filter string at all.
+    expect(() =>
+      buildListEventsFilter({ startAfter: "2026-01-01' or '" })
+    ).toThrow(/Invalid startAfter/);
+  });
+
+  test('accepts valid ISO 8601 datetimes in multiple forms', () => {
+    // Both `Z` (UTC) and offset forms parse cleanly.
+    expect(() =>
+      buildListEventsFilter({ startAfter: '2026-01-01T00:00:00Z' })
+    ).not.toThrow();
+    expect(() =>
+      buildListEventsFilter({ startBefore: '2026-06-05T17:00:00+01:00' })
+    ).not.toThrow();
   });
 });
 

--- a/test/calendar/list.test.js
+++ b/test/calendar/list.test.js
@@ -1,0 +1,159 @@
+const handleListEvents = require('../../calendar/list');
+const { buildListEventsFilter } = require('../../calendar/list');
+const { callGraphAPI } = require('../../utils/graph-api');
+const { ensureAuthenticated } = require('../../auth');
+
+jest.mock('../../utils/graph-api');
+jest.mock('../../auth');
+
+const mockAccessToken = 'test_token';
+
+/**
+ * Pull the queryParams object passed to callGraphAPI.
+ * Signature: (accessToken, method, path, body, queryParams, extraHeaders)
+ */
+function queryParamsOf(call) {
+  return call[4];
+}
+
+function filterOf(call) {
+  return queryParamsOf(call).$filter;
+}
+
+beforeEach(() => {
+  jest.resetAllMocks();
+  jest.spyOn(console, 'error').mockImplementation();
+  ensureAuthenticated.mockResolvedValue(mockAccessToken);
+  callGraphAPI.mockResolvedValue({ value: [] });
+});
+
+afterEach(() => {
+  console.error.mockRestore();
+});
+
+describe('handleListEvents — filter parameters', () => {
+  test('no-arg call preserves default "start >= now" behaviour', async () => {
+    const before = new Date();
+    await handleListEvents({});
+    const after = new Date();
+
+    expect(callGraphAPI).toHaveBeenCalledTimes(1);
+    const filter = filterOf(callGraphAPI.mock.calls[0]);
+
+    // Must use a single "start >= <iso>" condition (not combined with anything else).
+    const match = filter.match(/^start\/dateTime ge '([^']+)'$/);
+    expect(match).not.toBeNull();
+    const ts = new Date(match[1]);
+    // The timestamp captured by the handler must fall between the two test
+    // bookends — i.e. it is "now" at call time, as before.
+    expect(ts.getTime()).toBeGreaterThanOrEqual(before.getTime());
+    expect(ts.getTime()).toBeLessThanOrEqual(after.getTime());
+  });
+
+  test('startAfter overrides the default "now" filter', async () => {
+    await handleListEvents({ startAfter: '2026-01-01T00:00:00Z' });
+
+    expect(filterOf(callGraphAPI.mock.calls[0])).toBe(
+      "start/dateTime ge '2026-01-01T00:00:00Z'"
+    );
+  });
+
+  test('startBefore produces a strict upper bound on start', async () => {
+    await handleListEvents({ startBefore: '2026-02-01T00:00:00Z' });
+
+    expect(filterOf(callGraphAPI.mock.calls[0])).toBe(
+      "start/dateTime lt '2026-02-01T00:00:00Z'"
+    );
+  });
+
+  test('subject filter uses Graph contains()', async () => {
+    await handleListEvents({ subject: 'Miele' });
+
+    expect(filterOf(callGraphAPI.mock.calls[0])).toBe(
+      "contains(subject, 'Miele')"
+    );
+  });
+
+  test('combined startAfter + startBefore + subject are AND-ed together', async () => {
+    await handleListEvents({
+      startAfter: '2026-01-01T00:00:00Z',
+      startBefore: '2026-02-01T00:00:00Z',
+      subject: 'Miele',
+    });
+
+    expect(filterOf(callGraphAPI.mock.calls[0])).toBe(
+      [
+        "start/dateTime ge '2026-01-01T00:00:00Z'",
+        "start/dateTime lt '2026-02-01T00:00:00Z'",
+        "contains(subject, 'Miele')",
+      ].join(' and ')
+    );
+  });
+
+  test('single quotes in subject are escaped to prevent OData injection', async () => {
+    // The classic injection attempt: close the string literal, OR something
+    // that always matches, leave a trailing fragment. After escaping, the
+    // entire payload must remain inside a single quoted string literal so
+    // Graph treats it as a search substring, not as OData syntax.
+    await handleListEvents({ subject: "x') or '1'='1" });
+
+    const filter = filterOf(callGraphAPI.mock.calls[0]);
+
+    // Single quotes must be doubled per OData rules.
+    expect(filter).toBe("contains(subject, 'x'') or ''1''=''1')");
+
+    // Defence-in-depth: the filter must not contain a raw " or " operator
+    // sitting outside a quoted string. We strip out everything between
+    // matched single-quote pairs and assert no " or " is left in the
+    // skeleton.
+    const skeleton = stripQuotedStrings(filter);
+    expect(skeleton.toLowerCase()).not.toMatch(/\bor\b/);
+    expect(skeleton).not.toContain('=');
+  });
+
+  test('startAfter alone with subject does not include default "now"', async () => {
+    // Regression guard: once ANY filter param is present, the implicit "now"
+    // lower bound must NOT be silently added — that would surprise callers
+    // who specifically asked for past events.
+    await handleListEvents({
+      subject: 'Standup',
+    });
+
+    const filter = filterOf(callGraphAPI.mock.calls[0]);
+    expect(filter).toBe("contains(subject, 'Standup')");
+    expect(filter).not.toMatch(/start\/dateTime ge/);
+  });
+});
+
+describe('buildListEventsFilter — pure unit tests', () => {
+  test('returns default now filter for empty args', () => {
+    const before = new Date();
+    const filter = buildListEventsFilter({});
+    const after = new Date();
+
+    const match = filter.match(/^start\/dateTime ge '([^']+)'$/);
+    expect(match).not.toBeNull();
+    const ts = new Date(match[1]);
+    expect(ts.getTime()).toBeGreaterThanOrEqual(before.getTime());
+    expect(ts.getTime()).toBeLessThanOrEqual(after.getTime());
+  });
+
+  test('escapes single quotes in startAfter', () => {
+    // Defensive: even though ISO timestamps don't contain quotes,
+    // we don't trust the caller's input.
+    expect(buildListEventsFilter({ startAfter: "2026-01-01' or '" })).toBe(
+      "start/dateTime ge '2026-01-01'' or '''"
+    );
+  });
+});
+
+/**
+ * Remove anything between matched pairs of single quotes so we can
+ * inspect the OData "skeleton" outside quoted-string literals.
+ */
+function stripQuotedStrings(s) {
+  // OData escapes single quotes by doubling them inside a literal.
+  // A simple regex that consumes opening quote, any chars that are
+  // either non-quote or doubled-quote, then closing quote works.
+  return s.replace(/'(?:[^']|'')*'/g, "''");
+}


### PR DESCRIPTION
## Motivation

The `list-events` tool hardcodes a `start/dateTime ge '<now>'` filter, so any event that has already started (or that ended in the past) is invisible to the assistant. I hit this today trying to find a calendar event that started this morning — I had to bypass the MCP and call Graph API directly to locate it. Reasonable use cases like "find that meeting from last week" or "search my calendar for events titled 'X'" are currently impossible through the MCP.

## What this PR adds

Three optional parameters on `list-events`. They are pure additions — the schema's `required` array is still empty and the default behaviour with no args is unchanged.

| Param | Type | Description |
|-------|------|-------------|
| `startAfter` | ISO 8601 string | Only return events whose start is on or after this time. Replaces the default "now" lower bound when supplied. |
| `startBefore` | ISO 8601 string | Only return events whose start is strictly before this time. Combine with `startAfter` to bound a window. |
| `subject` | string | Case-insensitive substring match against event subject (uses Graph's `contains(subject, '...')`). |

## Backward compatibility

When all three parameters are absent, `list-events` builds exactly the same `start/dateTime ge '<now>'` filter as before. The moment ANY of the three is supplied, the implicit "now" lower bound is removed and the provided predicates are AND-ed together — that's the whole point: a caller who explicitly asks for past events should not be silently filtered down to the future.

## Security

User-supplied strings are passed through the existing `escapeODataString` helper (`'` → `''`) before interpolation into the `$filter`. A test verifies that an injection-style payload like `x') or '1'='1` ends up fully contained inside a single quoted-string literal and the resulting filter "skeleton" (with quoted segments stripped) contains no `or` keyword or `=` operator outside quotes.

## Test coverage (`test/calendar/list.test.js`)

1. No-arg call still filters to `start ≥ now` (captured timestamp falls between two test bookends, asserting it really is "now" at call time, not a constant).
2. `startAfter='2026-01-01T00:00:00Z'` overrides the default filter.
3. `startBefore='2026-02-01T00:00:00Z'` produces a strict upper bound.
4. `subject='Miele'` produces `contains(subject, 'Miele')`.
5. All three combined are AND-ed together in declaration order.
6. Single quotes in `subject` are escaped (skeleton-stripping check guards against `or 1=1` style injection).
7. Regression guard: subject-only filter does NOT silently re-introduce the default "now" lower bound.
8. Pure unit tests on the extracted `buildListEventsFilter` helper covering the default-now and quote-escape paths.

## Quality gates

- `npm test` — 757 / 757 passing (30 suites)
- `npm run lint` — no new errors; warnings are all pre-existing in unrelated files
- `npm run format:check` — clean
- Husky pre-commit hook ran lint-staged successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Calendar event search now supports optional filtering by start date range (startAfter, startBefore) and subject keyword matching. Default behavior preserved—upcoming events display automatically when no filters applied. Combine filters for targeted searches.

* **Tests**
  * Added unit tests validating calendar event filtering functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/littlebearapps/outlook-assistant/pull/193?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->