### PR TITLE
fix(auth): surface device-code (and all tool) errors instead of empty output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.8.2] - 2026-05
+
+Patch release fixing a silent-failure bug reported by a user whose team could
+not authenticate the Outlook connector in a remote (Claude Cowork) session:
+`auth action=authenticate method=device-code` "completed successfully but
+returned empty output" — no code, no URL — and status stayed "Not
+authenticated". Root cause was a tool-error that surfaced as empty output
+instead of a readable message. The fix makes **all** tool errors visible.
+
+### Fixed
+
+- **Device-code auth (and every tool) now surfaces failures as visible text
+  instead of empty output.** The `tools/call` dispatcher returned a
+  content-less `{ error }` object on any thrown handler error; the MCP SDK
+  coerces a result missing `content` into `{ content: [] }`, which clients
+  render as empty output while the call "succeeds". The dispatcher now returns
+  proper `{ content: [...], isError: true }` tool-error results. Extracted the
+  dispatch logic into `request-handler.js` so it is unit-tested. (#213)
+- **`auth` device-code step 1 no longer fails silently.** `handleDeviceCodeAuth`
+  now wraps initiation in try/catch (mirroring step 2) and returns an
+  actionable error with targeted hints for the common remote-connector failure
+  modes: `AADSTS9002331` audience mismatch (→ `OUTLOOK_AUTH_AUDIENCE=consumers`),
+  `invalid_client`/`unauthorized_client` (→ enable public client flows), and
+  blocked network egress to `login.microsoftonline.com`. (#213)
+
+### Changed
+
+- **Device-code HTTPS requests now time out after 15s** instead of hanging
+  indefinitely when outbound egress to `login.microsoftonline.com` is blocked
+  (e.g. a sandboxed connector), failing fast with a clear message. (#213)
+
 ## [3.8.1] - 2026-05
 
 Patch release driven by a glama.ai / safemcp.info scoring audit. Lifts the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,8 @@ Module layout, file organisation, and the v1→v3 tool-consolidation map live in
 
 | File | Purpose |
 |------|---------|
-| `index.js` | MCP protocol handler, combines all tools, runs schema coercion before each handler |
+| `index.js` | Entry point: combines all tools into `TOOLS`, creates the MCP server, wires `request-handler.js`, connects the stdio transport |
+| `request-handler.js` | MCP request dispatcher (extracted from `index.js` for testability): routes `initialize`/`tools/list`/`tools/call`, runs schema coercion, and returns tool errors as visible `isError` content (never empty output) |
 | `config.js` | API endpoint, auth settings, defaults |
 | `utils/schema-coerce.js` | MCP-boundary param coercion + validation (string→array/boolean/number, `additionalProperties: false`, required, enums) |
 | `auth/token-storage.js` | Token storage with auto-refresh at `~/.outlook-assistant-tokens.json` (includes `auth_method` field) |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -54,6 +54,12 @@ Larger surface-area additions and platform hardening. Roughly Q3 2026.
 
 ## Recently shipped
 
+- **v3.8.2** (May 2026) — fixed a silent-failure bug where `auth` device-code
+  authentication (and any tool error) returned empty output instead of a
+  readable message in remote connector sessions; all `tools/call` errors now
+  surface as visible `isError` content, device-code step 1 returns actionable
+  hints (audience mismatch, public-client flows, blocked egress), and
+  device-code HTTPS requests time out after 15s (#213).
 - **v3.8.0** (May 2026) — `manage-event update` action closing the modify-event competitive gap (#124, community PR #173 by @taranasus); `OUTLOOK_AUTH_AUDIENCE` env var fixing `AADSTS9002331` for personal-only Azure apps (community PR #174); `OUTLOOK_DEFAULT_TIMEZONE` env var overriding the hardcoded `Australia/Melbourne` default (community PR #175); README demo media now uses absolute URLs so it renders on npm (#171).
 - **v3.7.4** (May 2026) — F-24 chokepoint catches JSON-stringified arrays from MCP transport (#168); `search-emails kqlQuery` no longer silently drops on Step 0 fall-through (V37-F-1 part of #169); F-17 `maxResults` alias completion in list mode.
 - **v3.7.3** (May 2026) — E2E sweep fix-up. MCP boundary param coercion + validation, strict unknown-param rejection, param-name aliases across tools, file-output `outputDir` honoured, ID surfacing on creates, identity surface in `auth about`, safety-belt warnings.

--- a/auth/device-code.js
+++ b/auth/device-code.js
@@ -11,6 +11,10 @@ const https = require('https');
 const querystring = require('querystring');
 const config = require('../config');
 
+// Fail fast if the OAuth endpoint is unreachable (e.g. blocked outbound
+// egress in a sandboxed connector) instead of hanging indefinitely. (#213)
+const REQUEST_TIMEOUT_MS = 15000;
+
 /**
  * POST helper for OAuth2 endpoints
  * @param {string} url - Full URL to POST to
@@ -41,6 +45,13 @@ function postRequest(url, postData) {
       }
     );
     req.on('error', reject);
+    req.setTimeout(REQUEST_TIMEOUT_MS, () => {
+      req.destroy(
+        new Error(
+          'Device code request timed out — network egress to login.microsoftonline.com may be blocked.'
+        )
+      );
+    });
     req.write(postData);
     req.end();
   });

--- a/auth/tools.js
+++ b/auth/tools.js
@@ -208,10 +208,22 @@ async function handleDeviceCodeAuth() {
   }
 
   console.error('[AUTH] Starting device code flow...');
-  const response = await initiateDeviceCodeFlow(
-    clientId,
-    config.AUTH_CONFIG.scopes
-  );
+
+  // #213 — initiation can throw (blocked network egress in a sandboxed
+  // connector, AADSTS9002331 audience mismatch, invalid_client, non-JSON
+  // proxy page). Without this guard the exception propagates to the
+  // top-level dispatcher, which returns a content-less error and the client
+  // renders EMPTY OUTPUT. Mirror the try/catch that step 2
+  // (handleDeviceCodeComplete) already has, and surface actionable hints.
+  let response;
+  try {
+    response = await initiateDeviceCodeFlow(
+      clientId,
+      config.AUTH_CONFIG.scopes
+    );
+  } catch (error) {
+    return buildDeviceCodeErrorResponse(error);
+  }
 
   // Store in memory and persist to disk
   pendingDeviceCode = {
@@ -239,6 +251,57 @@ async function handleDeviceCodeAuth() {
         ].join('\n'),
       },
     ],
+  };
+}
+
+/**
+ * Build a visible, actionable MCP error result for a failed device-code
+ * initiation. Adds remediation hints for the common remote-connector
+ * failure modes. (#213)
+ * @param {Error} error
+ * @returns {object} - MCP response ({ content, isError: true })
+ */
+function buildDeviceCodeErrorResponse(error) {
+  const msg = (error && error.message) || String(error);
+  const code = error && error.code;
+  const hints = [];
+
+  if (/AADSTS9002331/i.test(msg) || /personal.*account/i.test(msg)) {
+    hints.push(
+      'This app registration appears to accept personal Microsoft accounts only. Set `OUTLOOK_AUTH_AUDIENCE=consumers` (or the correct tenant GUID) in your MCP env and retry.'
+    );
+  }
+  if (
+    /invalid_client|unauthorized_client|AADSTS7000218|AADSTS700016/i.test(msg)
+  ) {
+    hints.push(
+      "Enable 'Allow public client flows' under Azure → App registration → Authentication → Advanced settings, and add the `nativeclient` redirect URI (Mobile and desktop applications platform)."
+    );
+  }
+  if (
+    code === 'ENOTFOUND' ||
+    code === 'ETIMEDOUT' ||
+    code === 'ECONNREFUSED' ||
+    code === 'ECONNRESET' ||
+    /timed out|ENOTFOUND|ETIMEDOUT|ECONNREFUSED|ECONNRESET|network|Failed to parse response/i.test(
+      msg
+    )
+  ) {
+    hints.push(
+      'Could not reach `login.microsoftonline.com`. Outbound network access may be blocked in this environment (e.g. a sandboxed connector or corporate proxy). Check egress/firewall/proxy settings.'
+    );
+  }
+
+  const lines = ['## Device Code Authentication Failed', '', `Error: ${msg}`];
+  if (hints.length) {
+    lines.push('', 'Suggested fixes:', ...hints.map((h) => `- ${h}`));
+  }
+
+  console.error(`[AUTH] Device code initiation failed: ${msg}`);
+
+  return {
+    content: [{ type: 'text', text: lines.join('\n') }],
+    isError: true,
   };
 }
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -15,6 +15,7 @@ Common issues and their fixes. For getting-started guidance, see [`docs/how-to/g
 | `search-emails` returns no results | On personal accounts, `query` auto-falls back to subject search (v3.5.2). Use `subject`, `from`, `to`, `receivedAfter` filters for best results |
 | `create-event` wrong timezone | Omit the `Z` suffix on times for local timezone. `Z` suffix = UTC, which may be hours off |
 | Auth server "missing client ID" | Ensure `OUTLOOK_CLIENT_ID`/`OUTLOOK_CLIENT_SECRET` are set as env vars for the auth server process |
+| Device code `authenticate` returns nothing / empty output | Fixed in v3.8.2 — earlier versions rendered a failed initiation as empty output (the underlying error was swallowed). Update to v3.8.2+, which shows the real error plus a hint. Common causes: `AADSTS9002331` (set `OUTLOOK_AUTH_AUDIENCE=consumers`), `invalid_client` (enable public client flows), or blocked outbound network access to `login.microsoftonline.com` (e.g. a sandboxed connector). (#213) |
 | Device code "invalid_client" | Enable "Allow public client flows" in Azure Portal > App registrations > Authentication |
 | Device code sign-in shows "wrongplace" | Normal — sign-in completed. Close the browser, call `device-code-complete` |
 | Device code sign-in redirects to localhost | Use incognito/private browser for `microsoft.com/devicelogin` |

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ const {
   StdioServerTransport,
 } = require('@modelcontextprotocol/sdk/server/stdio.js');
 const config = require('./config');
-const { coerceArgsAgainstSchema } = require('./utils/schema-coerce');
+const { createRequestHandler } = require('./request-handler');
 
 // Import module tools
 const { authTools, setToolCount } = require('./auth');
@@ -69,118 +69,9 @@ const server = new Server(
   }
 );
 
-// Handle all requests
-server.fallbackRequestHandler = async (request) => {
-  try {
-    const { method, params, id } = request;
-    console.error(`REQUEST: ${method} [${id}]`);
-
-    // Initialize handler
-    if (method === 'initialize') {
-      console.error(`INITIALIZE REQUEST: ID [${id}]`);
-      return {
-        protocolVersion: '2024-11-05',
-        capabilities: {
-          tools: TOOLS.reduce((acc, tool) => {
-            acc[tool.name] = {};
-            return acc;
-          }, {}),
-        },
-        serverInfo: {
-          name: config.SERVER_NAME,
-          version: config.SERVER_VERSION,
-        },
-      };
-    }
-
-    // Tools list handler
-    if (method === 'tools/list') {
-      console.error(`TOOLS LIST REQUEST: ID [${id}]`);
-      console.error(`TOOLS COUNT: ${TOOLS.length}`);
-      console.error(`TOOLS NAMES: ${TOOLS.map((t) => t.name).join(', ')}`);
-
-      return {
-        tools: TOOLS.map((tool) => ({
-          name: tool.name,
-          description: tool.description,
-          inputSchema: tool.inputSchema,
-          ...(tool.annotations && { annotations: tool.annotations }),
-        })),
-      };
-    }
-
-    // Required empty responses for other capabilities
-    if (method === 'resources/list') return { resources: [] };
-    if (method === 'prompts/list') return { prompts: [] };
-
-    // Tool call handler
-    if (method === 'tools/call') {
-      try {
-        const { name, arguments: args = {} } = params || {};
-
-        console.error(`TOOL CALL: ${name}`);
-
-        // Find the tool handler
-        const tool = TOOLS.find((t) => t.name === name);
-
-        if (tool && tool.handler) {
-          // Coerce + validate args against the tool's inputSchema before
-          // dispatching. Catches array-as-string, boolean-as-string, unknown
-          // params, and out-of-enum action values at the MCP boundary so
-          // handlers receive properly-typed JS values. (#160, #162)
-          if (tool.inputSchema) {
-            const coerced = coerceArgsAgainstSchema(args, tool.inputSchema);
-            if (coerced.error) {
-              return {
-                content: [
-                  {
-                    type: 'text',
-                    text: `Invalid arguments for tool '${name}':\n${coerced.error}`,
-                  },
-                ],
-                isError: true,
-              };
-            }
-            return await tool.handler(coerced.args);
-          }
-          return await tool.handler(args);
-        }
-
-        // Tool not found
-        return {
-          error: {
-            code: -32601,
-            message: `Tool not found: ${name}`,
-          },
-        };
-      } catch (error) {
-        console.error(`Error in tools/call:`, error);
-        return {
-          error: {
-            code: -32603,
-            message: `Error processing tool call: ${error.message}`,
-          },
-        };
-      }
-    }
-
-    // For any other method, return method not found
-    return {
-      error: {
-        code: -32601,
-        message: `Method not found: ${method}`,
-      },
-    };
-  } catch (error) {
-    console.error(`Error in fallbackRequestHandler:`, error);
-    return {
-      error: {
-        code: -32603,
-        message: `Error processing request: ${error.message}`,
-      },
-    };
-  }
-};
+// Handle all requests. Dispatch + error-shaping logic lives in
+// request-handler.js so it is unit-testable without starting the transport.
+server.fallbackRequestHandler = createRequestHandler(TOOLS);
 
 // Make the script executable
 process.on('SIGTERM', () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@littlebearapps/outlook-assistant",
-  "version": "3.8.1",
+  "version": "3.8.2",
   "mcpName": "io.github.littlebearapps/outlook-assistant",
   "description": "Outlook Assistant — MCP server with 22 tools for email, calendar, contacts, and settings via Microsoft Graph API",
   "main": "index.js",
@@ -38,7 +38,9 @@
     "calendar",
     "contacts",
     "model-context-protocol",
-    "anthropic"
+    "mcp-server",
+    "anthropic",
+    "outlook-assistant"
   ],
   "author": "Little Bear Apps <hello@littlebearapps.com>",
   "license": "MIT",

--- a/request-handler.js
+++ b/request-handler.js
@@ -1,0 +1,144 @@
+/**
+ * MCP request dispatcher for the Outlook Assistant server.
+ *
+ * Extracted from index.js so the dispatch + error-shaping logic is
+ * unit-testable without starting the stdio transport.
+ *
+ * IMPORTANT (#213): a `tools/call` that fails MUST return a visible MCP
+ * tool-error result (`{ content: [...], isError: true }`). Returning a
+ * content-less `{ error: {...} }` object gets coerced by the SDK into
+ * `{ content: [] }`, which the client renders as EMPTY OUTPUT — the exact
+ * symptom reported for device-code auth in a remote connector session.
+ */
+const config = require('./config');
+const { coerceArgsAgainstSchema } = require('./utils/schema-coerce');
+
+/**
+ * Build the MCP fallbackRequestHandler for a given tool set.
+ * @param {Array<{name: string, description?: string, inputSchema?: object, annotations?: object, handler?: Function}>} TOOLS
+ * @returns {(request: object) => Promise<object>}
+ */
+function createRequestHandler(TOOLS) {
+  return async (request) => {
+    try {
+      const { method, params, id } = request;
+      console.error(`REQUEST: ${method} [${id}]`);
+
+      // Initialize handler
+      if (method === 'initialize') {
+        console.error(`INITIALIZE REQUEST: ID [${id}]`);
+        return {
+          protocolVersion: '2024-11-05',
+          capabilities: {
+            tools: TOOLS.reduce((acc, tool) => {
+              acc[tool.name] = {};
+              return acc;
+            }, {}),
+          },
+          serverInfo: {
+            name: config.SERVER_NAME,
+            version: config.SERVER_VERSION,
+          },
+        };
+      }
+
+      // Tools list handler
+      if (method === 'tools/list') {
+        console.error(`TOOLS LIST REQUEST: ID [${id}]`);
+        console.error(`TOOLS COUNT: ${TOOLS.length}`);
+        console.error(`TOOLS NAMES: ${TOOLS.map((t) => t.name).join(', ')}`);
+
+        return {
+          tools: TOOLS.map((tool) => ({
+            name: tool.name,
+            description: tool.description,
+            inputSchema: tool.inputSchema,
+            ...(tool.annotations && { annotations: tool.annotations }),
+          })),
+        };
+      }
+
+      // Required empty responses for other capabilities
+      if (method === 'resources/list') return { resources: [] };
+      if (method === 'prompts/list') return { prompts: [] };
+
+      // Tool call handler
+      if (method === 'tools/call') {
+        try {
+          const { name, arguments: args = {} } = params || {};
+
+          console.error(`TOOL CALL: ${name}`);
+
+          // Find the tool handler
+          const tool = TOOLS.find((t) => t.name === name);
+
+          if (tool && tool.handler) {
+            // Coerce + validate args against the tool's inputSchema before
+            // dispatching. Catches array-as-string, boolean-as-string, unknown
+            // params, and out-of-enum action values at the MCP boundary so
+            // handlers receive properly-typed JS values. (#160, #162)
+            if (tool.inputSchema) {
+              const coerced = coerceArgsAgainstSchema(args, tool.inputSchema);
+              if (coerced.error) {
+                return {
+                  content: [
+                    {
+                      type: 'text',
+                      text: `Invalid arguments for tool '${name}':\n${coerced.error}`,
+                    },
+                  ],
+                  isError: true,
+                };
+              }
+              return await tool.handler(coerced.args);
+            }
+            return await tool.handler(args);
+          }
+
+          // Tool not found — return visible isError content, not a
+          // content-less { error } (which renders as empty output). (#213)
+          return {
+            content: [
+              {
+                type: 'text',
+                text: `Tool not found: ${name}`,
+              },
+            ],
+            isError: true,
+          };
+        } catch (error) {
+          console.error(`Error in tools/call:`, error);
+          // Surface the failure as visible tool-error content so it is not
+          // silently rendered as empty output by the client. (#213)
+          return {
+            content: [
+              {
+                type: 'text',
+                text: `Error processing tool call: ${error.message}`,
+              },
+            ],
+            isError: true,
+          };
+        }
+      }
+
+      // For any other method, return method not found
+      return {
+        error: {
+          code: -32601,
+          message: `Method not found: ${method}`,
+        },
+      };
+    } catch (error) {
+      console.error(`Error in fallbackRequestHandler:`, error);
+      return {
+        error: {
+          code: -32603,
+          message: `Error processing request: ${error.message}`,
+        },
+      };
+    }
+  };
+}
+
+module.exports = { createRequestHandler };

--- a/test/auth/auth-tools.test.js
+++ b/test/auth/auth-tools.test.js
@@ -216,6 +216,63 @@ describe('device code state persistence', () => {
   });
 });
 
+// #213 — device-code step 1 must surface failures as visible, actionable
+// error content instead of throwing (which the top-level dispatcher used to
+// convert into empty output). Mirrors the try/catch step 2 already has.
+describe('handleDeviceCodeAuth — visible errors on failure (#213)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    console.error.mockRestore();
+  });
+
+  test('returns visible isError content (not empty, no throw) when initiation fails', async () => {
+    initiateDeviceCodeFlow.mockRejectedValue(
+      new Error(
+        'AADSTS9002331: Application is configured for personal Microsoft accounts only'
+      )
+    );
+
+    const result = await handleDeviceCodeAuth();
+
+    expect(result).toBeDefined();
+    expect(result.isError).toBe(true);
+    expect(Array.isArray(result.content)).toBe(true);
+    expect(result.content[0].text).toContain('AADSTS9002331');
+  });
+
+  test('includes audience-mismatch remediation hint for AADSTS9002331', async () => {
+    initiateDeviceCodeFlow.mockRejectedValue(
+      new Error('AADSTS9002331: audience mismatch on /common')
+    );
+
+    const result = await handleDeviceCodeAuth();
+    expect(result.content[0].text).toMatch(/OUTLOOK_AUTH_AUDIENCE=consumers/);
+  });
+
+  test('includes public-client-flow hint for invalid_client', async () => {
+    initiateDeviceCodeFlow.mockRejectedValue(
+      new Error('invalid_client: AADSTS7000218 public client flow not enabled')
+    );
+
+    const result = await handleDeviceCodeAuth();
+    expect(result.content[0].text).toMatch(/public client flows/i);
+  });
+
+  test('includes network-egress hint on connection failure', async () => {
+    const err = new Error('connect ETIMEDOUT 20.190.190.1:443');
+    err.code = 'ETIMEDOUT';
+    initiateDeviceCodeFlow.mockRejectedValue(err);
+
+    const result = await handleDeviceCodeAuth();
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/login\.microsoftonline\.com/);
+  });
+});
+
 describe('handleAbout — F-1/F-2/F-48', () => {
   const originalEnv = process.env;
 

--- a/test/auth/device-code.test.js
+++ b/test/auth/device-code.test.js
@@ -27,6 +27,8 @@ function mockHttpsResponse(statusCode, body) {
   };
   const mockReq = {
     on: jest.fn(),
+    setTimeout: jest.fn(),
+    destroy: jest.fn(),
     write: jest.fn(),
     end: jest.fn(),
   };
@@ -90,6 +92,28 @@ describe('device-code', () => {
 
       const result = await initiateDeviceCodeFlow('test-client', ['Mail.Read']);
       expect(result.interval).toBe(5);
+    });
+
+    // #191 — a hung request (e.g. blocked outbound egress in a sandboxed
+    // connector) must fail fast with a clear timeout error rather than hang.
+    it('rejects with a timeout message when the request times out', async () => {
+      const mockReq = {
+        on: jest.fn(),
+        setTimeout: jest.fn((_ms, cb) => cb()), // fire the timeout immediately
+        write: jest.fn(),
+        end: jest.fn(),
+      };
+      // destroy(err) re-emits via the registered 'error' handler (Node behaviour)
+      mockReq.destroy = jest.fn((err) => {
+        const errCall = mockReq.on.mock.calls.find((c) => c[0] === 'error');
+        if (errCall) errCall[1](err);
+      });
+      // Never invoke the response callback — simulates no response / hang
+      https.request.mockImplementationOnce(() => mockReq);
+
+      await expect(
+        initiateDeviceCodeFlow('test-client', ['Mail.Read'])
+      ).rejects.toThrow(/timed out/i);
     });
   });
 

--- a/test/dispatcher/tool-call-error-shape.test.js
+++ b/test/dispatcher/tool-call-error-shape.test.js
@@ -1,0 +1,81 @@
+// #213 — tools/call errors must be returned as visible MCP tool-error
+// content ({ content: [...], isError: true }), NOT as a content-less
+// { error: {...} } object. The MCP SDK coerces a result missing `content`
+// into `{ content: [] }`, which the client renders as EMPTY OUTPUT — the
+// exact symptom reported for device-code auth in a remote connector session.
+//
+// The dispatch/error-shaping logic lives in `createRequestHandler` (extracted
+// from index.js so it is unit-testable without starting the stdio server).
+const { createRequestHandler } = require('../../request-handler');
+
+describe('createRequestHandler — tools/call error shaping (#213)', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    console.error.mockRestore();
+  });
+
+  test('a throwing tool handler yields visible isError content, not empty { error }', async () => {
+    const TOOLS = [
+      {
+        name: 'boom',
+        handler: async () => {
+          throw new Error('kaboom');
+        },
+      },
+    ];
+    const handler = createRequestHandler(TOOLS);
+
+    const result = await handler({
+      method: 'tools/call',
+      params: { name: 'boom', arguments: {} },
+      id: 1,
+    });
+
+    // Must NOT be a content-less error object (which renders as empty output)
+    expect(result.error).toBeUndefined();
+    expect(result.isError).toBe(true);
+    expect(Array.isArray(result.content)).toBe(true);
+    expect(result.content.length).toBeGreaterThan(0);
+    expect(result.content[0].text).toMatch(
+      /Error processing tool call.*kaboom/
+    );
+  });
+
+  test('unknown tool yields visible isError content, not empty { error }', async () => {
+    const handler = createRequestHandler([]);
+
+    const result = await handler({
+      method: 'tools/call',
+      params: { name: 'nope', arguments: {} },
+      id: 2,
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/Tool not found: nope/);
+  });
+
+  test('a successful tool handler result is passed through unchanged', async () => {
+    const TOOLS = [
+      {
+        name: 'ok',
+        handler: async () => ({
+          content: [{ type: 'text', text: 'all good' }],
+        }),
+      },
+    ];
+    const handler = createRequestHandler(TOOLS);
+
+    const result = await handler({
+      method: 'tools/call',
+      params: { name: 'ok', arguments: {} },
+      id: 3,
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0].text).toBe('all good');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes a silent-failure bug reported via LinkedIn (a user's team could not authenticate the Outlook connector in a Claude Cowork session): `auth action=authenticate method=device-code` "completed successfully but returned **empty output**" — no code, no URL — and status stayed "Not authenticated".

## Root cause

`handleDeviceCodeAuth` called `initiateDeviceCodeFlow` with **no try/catch**. When the HTTPS request to Microsoft throws (blocked outbound egress in a sandboxed connector, `AADSTS9002331` audience mismatch, `invalid_client`, or a non-JSON proxy page), the exception propagated to the top-level `tools/call` catch in `index.js`, which returned a content-less `{ error }`. The MCP SDK coerces a result missing `content` into `{ content: [] }`, so the client renders **empty output** while the call "succeeds". This affected the error path of **all 22 tools**, not just auth.

## Changes

- **`request-handler.js` (new)** — extracted the MCP dispatcher from `index.js` so it is unit-testable; `tools/call` errors now return visible `{ content, isError: true }` instead of a content-less `{ error }`.
- **`auth/tools.js`** — `handleDeviceCodeAuth` wraps initiation in try/catch (mirroring step 2) and returns the real error plus actionable hints (audience mismatch → `OUTLOOK_AUTH_AUDIENCE=consumers`; `invalid_client` → enable public client flows; blocked egress to `login.microsoftonline.com`).
- **`auth/device-code.js`** — 15s HTTPS timeout so blocked egress fails fast instead of hanging.
- Tests for all three paths; `CHANGELOG`/`ROADMAP`/`troubleshooting`/`CLAUDE.md` updated; **v3.8.2** bump.

## Testing

- `npm test` — 756 pass (30 suites), incl. 5 new tests written red-first.
- `npm run lint` — 0 errors. `npm run format:check` — clean.

Closes #213

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tool and dispatcher failures now appear as visible error messages instead of empty output.
  * Device-code authentication failures now provide actionable guidance for common identity and network issues.
  * Microsoft authentication requests now time out after 15 seconds instead of hanging indefinitely.
* **Documentation**
  * Added troubleshooting guidance for empty device-code authentication responses.
  * Updated release and roadmap information for version 3.8.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->