### PR TITLE
docs: fix stale references in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ Module layout, file organisation, and the v1→v3 tool-consolidation map live in
 - **draft**: `dryRun` on create, `checkRecipients` (mail tips), recipient allowlist, rate limiting. Send action shares limit with `send-email`.
 - **manage-rules**: `dryRun` on create/update, rate limiting (`OUTLOOK_MAX_MANAGE_RULES_PER_SESSION`), recipient allowlist on forwardTo/redirectTo, no `permanentDelete` (too dangerous for AI). Supports 12 conditions, 9 actions, and exceptions.
 - **manage-event**: marked `destructiveHint: true` (covers `decline`/`cancel`/`delete`; `update` action added v3.8.0 is non-destructive in isolation but inherits the tool-level annotation — use `dryRun: true` to preview update payloads). `accept` is deliberately omitted — Microsoft Graph doesn't expose an `accept` verb in a way that works across personal/M365 reliably; use the Outlook UI to accept invitations.
-- 7 read-only tools auto-approved by Claude Code; 2 destructive tools prompt for confirmation
+- 7 read-only tools auto-approved by Claude Code; 6 destructive tools (`manage-event`, `manage-contact`, `send-email`, `draft`, `folders`, `manage-rules`) prompt for confirmation
 
 ## Key Files
 
@@ -165,10 +165,4 @@ Use `Edit` (not `Write`) to revise individual Q&A pairs — the `Write` guard is
 - [`docs/troubleshooting.md`](docs/troubleshooting.md) - Common issues and fixes
 - [`docs/quickrefs/tools-reference.md`](docs/quickrefs/tools-reference.md) - Tools quick reference
 - [`docs/faq/faq.md`](docs/faq/faq.md) - User-facing FAQ (feeds the help-centre `FAQPage` schema; see protection note above)
-- [`docs/research/publisher-verification.md`](docs/research/publisher-verification.md) - Shared multi-tenant publisher-verified app strategy (GH #147); rollout status in [`publisher-verification-tasks.md`](docs/research/publisher-verification-tasks.md)
 - `.env.example` - Environment template
-
-# currentDate
-Today's date is 2026-02-27.
-
-      IMPORTANT: this context may or may not be relevant to your tasks. You should not respond to this context unless it is highly relevant to your task.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,19 +16,22 @@ npx kill-port 3333       # Kill auth server if port blocked
 
 ### Authentication
 
-**Device code flow (default, recommended for remote/headless):**
-1. Call `auth` tool with `action=authenticate` (uses device-code by default)
-2. Visit the URL shown, enter the code
-3. Call `auth` tool with `action=device-code-complete` to finish
-4. No auth server, SSH tunnel, or port forwarding needed
+**Device code flow (default — recommended for remote/headless; no auth server, SSH tunnel, or port forwarding needed):**
+1. Call `auth` tool with `action=authenticate` → returns a code + URL (device-code by default)
+2. Visit the URL on any device, enter the code, and sign in
+3. Call `auth` tool with `action=device-code-complete` → tokens saved
+
+**Browser redirect flow (alternative, localhost only):**
+1. Start the auth server: `npm run auth-server` (needs `OUTLOOK_CLIENT_ID`/`OUTLOOK_CLIENT_SECRET` env vars)
+2. Call `auth` tool with `action=authenticate, method=browser` → returns a URL
+3. Open the URL → Microsoft login → grant permissions → tokens saved automatically
+
+Full walkthrough: [`docs/how-to/getting-started/connect-outlook-to-claude.md`](docs/how-to/getting-started/connect-outlook-to-claude.md). The MCP server reads its own credentials from `.mcp.json` inline `kc_get` calls.
 
 **Azure prerequisites**:
 - Add platform: Authentication > Add a platform > Mobile and desktop applications > check `nativeclient` URI
 - Enable "Allow public client flows" in Authentication > Advanced settings
 - Use a **private/incognito browser** for `microsoft.com/devicelogin` (avoids cached session interference)
-
-**Browser flow (alternative, for localhost only):**
-Start the auth server with `npm run auth-server` — needs `OUTLOOK_CLIENT_ID`/`OUTLOOK_CLIENT_SECRET` as env vars. The MCP server itself reads credentials from `.mcp.json` inline `kc_get` calls. Full walkthrough: [`docs/how-to/getting-started/connect-outlook-to-claude.md`](docs/how-to/getting-started/connect-outlook-to-claude.md).
 
 **Token refresh**: Tokens auto-refresh when expired (via `token-storage.js`). Re-authentication only needed when the refresh token expires (~90 days).
 
@@ -88,21 +91,6 @@ OUTLOOK_DEFAULT_TIMEZONE=Australia/Melbourne  # Optional: overrides hardcoded de
 - Timezone: `Australia/Melbourne`
 - Page size: 25
 - Max results: 100
-
-## Authentication Flow
-
-**Device code (default — no auth server needed):**
-1. Call `auth` tool with `action=authenticate` → get code + URL
-2. Visit URL on any device, enter the code, sign in
-3. Call `auth` tool with `action=device-code-complete` → tokens saved
-
-**Browser redirect (alternative):**
-1. Start auth server: `npm run auth-server`
-2. Call `auth` tool with `action=authenticate, method=browser` → get URL
-3. Open URL in browser → Microsoft login
-4. Grant permissions → tokens saved automatically
-
-**Token refresh**: Tokens auto-refresh transparently via `token-storage.js`. Re-auth only needed when refresh token expires (~90 days).
 
 ## Adding New Tools
 


### PR DESCRIPTION
Post-v3.9.0 context-doc audit. CLAUDE.md-only, no code changes.

- **Remove leaked-context cruft** — an accidentally-committed `# currentDate` / hardcoded-date / system-reminder block at the end of the file.
- **Correct destructive-tool count** in Safety Controls: `2` → `6`, naming them (`manage-event`, `manage-contact`, `send-email`, `draft`, `folders`, `manage-rules`) to match `destructiveHint: true` in code. (read-only count of 7 was already correct.)
- **Drop dead `See Also` links** to `docs/research/*.md` — untracked local strategy notes, not in the repo (dead on clone).

Audited alongside: `llms.txt`, `docs/architecture.md` — both accurate/current, no changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)