### PR TITLE
fix(build): include request-handler.js in published tarball (v3.9.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [3.9.0] - 2026-07
+## [3.9.1] - 2026-08
+
+Packaging hotfix. **Every published release from 3.9.0 back to 3.8.2 is
+unusable when installed from npm** — this restores a working install. No
+behavioural changes; the source tree was never affected.
+
+### Fixed
+
+- **`request-handler.js` is now included in the published tarball.** v3.8.2
+  extracted the `tools/call` dispatcher into `request-handler.js` and
+  `index.js` requires it at load time, but the file was never added to the
+  `files` allowlist in `package.json`. It was therefore excluded from every
+  tarball published since, so a fresh install died immediately with:
+
+  ```
+  Error: Cannot find module './request-handler'
+  ```
+
+  Affected published versions: **3.8.2** and **3.9.0** (3.8.3 was never
+  published). **3.8.1 was the last working release.** Running from a git
+  checkout was unaffected, which is why local testing and CI — both of which
+  run against the working tree, not the packed tarball — did not catch it.
+
+  `npm pack` now emits 62 files (was 61). Verified by installing the packed
+  tarball into a clean directory and completing an MCP `initialize` +
+  `tools/list` handshake: all 22 tools present.
+
+### Notes
+
+- Consider adding a CI job that installs the output of `npm pack` and runs a
+  handshake against it. The existing suite passes 826/826 against the working
+  tree and still missed a broken package for two releases.
 
 Feature release adding nested-folder addressing and making cross-folder email
 search reliable. Validated with a live end-to-end sweep against a personal

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@littlebearapps/outlook-assistant",
-  "version": "3.9.0",
+  "version": "3.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@littlebearapps/outlook-assistant",
-      "version": "3.9.0",
+      "version": "3.9.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@littlebearapps/outlook-assistant",
-  "version": "3.9.0",
+  "version": "3.9.1",
   "mcpName": "io.github.littlebearapps/outlook-assistant",
   "description": "Outlook Assistant — MCP server with 22 tools for email, calendar, contacts, and settings via Microsoft Graph API",
   "main": "index.js",
@@ -58,6 +58,7 @@
   "files": [
     "index.js",
     "config.js",
+    "request-handler.js",
     "outlook-auth-server.js",
     "auth/",
     "calendar/",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/littlebearapps/outlook-assistant",
     "source": "github"
   },
-  "version": "3.9.0",
+  "version": "3.9.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@littlebearapps/outlook-assistant",
-      "version": "3.9.0",
+      "version": "3.9.1",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary

**Every npm release from 3.8.2 onward is dead on arrival.** A fresh install exits immediately:

```
Error: Cannot find module './request-handler'
```

v3.8.2 extracted the `tools/call` dispatcher into `request-handler.js` and `index.js` requires it at load time, but the file was never added to the `files` allowlist in `package.json` — so it has been excluded from every tarball published since.

| Version | `request-handler.js` in tarball | `index.js` requires it | Result |
|---|---|---|---|
| 3.7.2 – 3.8.1 | ✗ | ✗ | works |
| **3.8.2** | ✗ | ✓ | **broken** |
| 3.8.3 | — | — | never published |
| **3.9.0** | ✗ | ✓ | **broken** |

**3.8.1 is the last working published release.** Confirmed by downloading and listing every tarball from 3.7.2 to 3.9.0.

## Why CI missed it

Both the test suite and CI exercise the **working tree**, never the packed tarball. Running from a git checkout was always fine — the source tree was never affected. This is purely a packaging defect, and it shipped twice.

## The fix

One line: `"request-handler.js"` added to `files`. Version bumped to **3.9.1**.

## Verification

- `npm pack` now emits **62 files** (was 61)
- Installed the packed tarball into a clean directory and completed an MCP `initialize` + `tools/list` handshake — **all 22 tools present**, `serverInfo.version` reports `3.9.1`
- Audited every other root-level `require('./…')` in `index.js`; `request-handler.js` was the only gap
- Local gates: lint 0 errors, **826 tests / 33 suites passed**, `npm audit --omit=dev --audit-level=high` exit 0

## Follow-up worth considering

Add a CI job that installs the output of `npm pack` and runs a handshake against it. 826 passing tests did not stop a broken package shipping for two releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed installation failures caused by a missing file in published packages.
  * Ensured the required request-handling functionality is included in package downloads.

* **Release**
  * Released version 3.9.1 with updated package and server metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->