### PR TITLE
fix(deps): clear the production audit gate and watch for regressions (#215)

### DIFF
--- a/.github/workflows/scheduled-audit.yml
+++ b/.github/workflows/scheduled-audit.yml
@@ -21,6 +21,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          # This job holds an issues:write token and runs `npm ci`, which
+          # executes dependency lifecycle scripts. Don't leave the token in
+          # .git/config where those scripts could read it.
+          persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '20'
@@ -50,12 +55,16 @@ jobs:
         with:
           script: |
             const title = 'Security audit gate failing on main (production deps)';
-            const { data: existing } = await github.rest.issues.listForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'open',
-              labels: 'security',
-            });
+            const existing = await github.paginate(
+              github.rest.issues.listForRepo,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                state: 'open',
+                labels: 'security',
+                per_page: 100,
+              }
+            );
             const body = [
               '`npm audit --omit=dev --audit-level=high` is failing on `main`.',
               'This blocks every pull request, because the same command is a required',
@@ -70,7 +79,10 @@ jobs:
               '',
               `Run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
             ].join('\n');
-            const match = existing.find((i) => i.title === title);
+            // listForRepo returns pull requests too — skip them.
+            const match = existing.find(
+              (i) => !i.pull_request && i.title === title
+            );
             if (match) {
               await github.rest.issues.createComment({
                 owner: context.repo.owner,

--- a/.github/workflows/scheduled-audit.yml
+++ b/.github/workflows/scheduled-audit.yml
@@ -1,0 +1,93 @@
+name: Scheduled Security Audit
+
+# The audit gate in ci.yml only runs on push/PR, so a pinned `overrides` entry can
+# silently rot back into a published advisory range with no signal until the next PR
+# fails (issue #215, hit twice). This job watches for that on a schedule and files an
+# issue when the production dependency tree goes vulnerable.
+
+on:
+  schedule:
+    # 03:00 UTC every Monday
+    - cron: '0 3 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  audit:
+    name: Audit production dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+
+      - name: Run security audit (production deps)
+        id: audit
+        run: |
+          set +e
+          npm audit --omit=dev --audit-level=high > audit.txt 2>&1
+          code=$?
+          set -e
+          {
+            echo 'report<<AUDIT_EOF'
+            cat audit.txt
+            echo 'AUDIT_EOF'
+          } >> "$GITHUB_OUTPUT"
+          echo "exit_code=$code" >> "$GITHUB_OUTPUT"
+          cat audit.txt
+
+      - name: Open an issue when the gate fails
+        if: steps.audit.outputs.exit_code != '0'
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        env:
+          AUDIT_REPORT: ${{ steps.audit.outputs.report }}
+        with:
+          script: |
+            const title = 'Security audit gate failing on main (production deps)';
+            const { data: existing } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'security',
+            });
+            const body = [
+              '`npm audit --omit=dev --audit-level=high` is failing on `main`.',
+              'This blocks every pull request, because the same command is a required',
+              'check in `.github/workflows/ci.yml`.',
+              '',
+              'Check the `overrides` block in `package.json` first — a pinned floor',
+              'rotting back into an advisory range is the recurring cause.',
+              '',
+              '```',
+              process.env.AUDIT_REPORT,
+              '```',
+              '',
+              `Run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+            ].join('\n');
+            const match = existing.find((i) => i.title === title);
+            if (match) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: match.number,
+                body,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                labels: ['security'],
+                body,
+              });
+            }
+
+      - name: Fail the run when the gate fails
+        if: steps.audit.outputs.exit_code != '0'
+        run: exit 1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1062,9 +1062,9 @@
       "license": "MIT"
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "1.19.17",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.17.tgz",
+      "integrity": "sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -5261,9 +5261,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",
@@ -5779,9 +5779,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.31",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.31.tgz",
-      "integrity": "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==",
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.7.tgz",
+      "integrity": "sha512-c8/gF9ac8Y78/agExVocyLevgR+JlpNB444Py0FSX8pJoPdYUfUzRcXtYEYGwt6l19qIlVZPN5Mfsw9jFShmQQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -5973,9 +5973,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.7.0.tgz",
+      "integrity": "sha512-BGFsyJd5mpXp3rK6jIdADLNgpJUK1jnjzvYF8lK+VyDab9JAmqN0YOKDdP17HlgKb2+ehPgDc8EtnRLbGCAMhA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -8164,12 +8164,13 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.15.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
-      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -8722,14 +8723,14 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -8741,13 +8742,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"

--- a/package.json
+++ b/package.json
@@ -98,8 +98,11 @@
   },
   "overrides": {
     "minimatch": ">=3.1.3",
-    "hono": "^4.12.31",
-    "fast-uri": "^3.1.4",
+    "hono": "^4.13.7",
+    "@hono/node-server": "^1.19.17",
+    "fast-uri": "^3.1.7",
+    "ip-address": "^10.7.0",
+    "qs": "^6.16.0",
     "body-parser": "^2.3.0"
   }
 }


### PR DESCRIPTION
## Why

`npm audit --omit=dev --audit-level=high` was exiting 1 on `main`. That exact command is a required CI job (`.github/workflows/ci.yml`), so **every pull request was blocked** until it cleared. This is #215, and it is the second time this failure mode has hit.

Two HIGH advisories were live in the production tree:

| Package | Was | Vulnerable range | Reached via |
|---|---|---|---|
| `fast-uri` | 3.1.4 | 3.0.0 – 3.1.5 | **our own override floor sat inside the range** |
| `ip-address` | 10.2.0 | <= 10.3.0 | `@modelcontextprotocol/sdk` → `express-rate-limit`, no override |

Plus moderates in `hono` (<= 4.13.4), `@hono/node-server` (< 1.19.15) and `qs` (2.2.5 – 6.15.3).

## What changed

`package.json` overrides, each bumped to the lowest safe floor **inside the major its parent already declares**, so no dependency range is broken:

| Package | Floor | Parent's declared range | Still satisfied |
|---|---|---|---|
| `fast-uri` | `^3.1.7` | `ajv` wants `^3.0.1` | ✅ |
| `ip-address` | `^10.7.0` | `express-rate-limit` wants `^10.2.0` | ✅ |
| `hono` | `^4.13.7` | sdk wants `^4.11.4` | ✅ |
| `@hono/node-server` | `^1.19.17` | sdk wants `^1.19.9` | ✅ (stays on 1.x) |
| `qs` | `^6.16.0` | `express` / `body-parser` want `^6.14.0` / `^6.15.2` | ✅ |

`package-lock.json` regenerated to match.

## Plus: a watchdog

New `.github/workflows/scheduled-audit.yml` runs the same gate weekly (and on demand) and opens — or comments on — a `security`-labelled issue when it fails.

The gate in `ci.yml` only fires on push and pull request. A pinned override floor rotting back into a newly published advisory range produces no signal at all until someone's unrelated PR fails for reasons they didn't cause. That is exactly how #215 happened twice. This closes the observability gap.

## Verification

```
npm audit --omit=dev --audit-level=high   # exit 0, "found 0 vulnerabilities"
npm audit --omit=dev                      # found 0 vulnerabilities (moderates cleared too)
npm test                                  # 33 suites, 826 tests, all passing
npm run lint                              # 0 errors
```

No source files touched — dependency floors and one new workflow only.

Closes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added automated weekly production security audits, with support for manual runs.
  - Audit failures now generate or update a security issue and clearly mark the audit run as unsuccessful.
  - Updated security-related package version controls to incorporate newer approved versions and address known vulnerability risks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->